### PR TITLE
Adding support for a custom endpoint for Resource Manager

### DIFF
--- a/authentication/builder.go
+++ b/authentication/builder.go
@@ -14,6 +14,10 @@ type Builder struct {
 	TenantID       string
 	Environment    string
 
+	// The custom Resource Manager Endpoint which should be used
+	// only applicable for Azure Stack at this time.
+	CustomResourceManagerEndpoint string
+
 	// Azure CLI Parsing / CloudShell Auth
 	SupportsAzureCliCloudShellParsing bool
 
@@ -35,10 +39,11 @@ type Builder struct {
 // for authenticating with Azure
 func (b Builder) Build() (*Config, error) {
 	config := Config{
-		ClientID:       b.ClientID,
-		SubscriptionID: b.SubscriptionID,
-		TenantID:       b.TenantID,
-		Environment:    b.Environment,
+		ClientID:                      b.ClientID,
+		SubscriptionID:                b.SubscriptionID,
+		TenantID:                      b.TenantID,
+		Environment:                   b.Environment,
+		CustomResourceManagerEndpoint: b.CustomResourceManagerEndpoint,
 	}
 
 	// NOTE: the ordering here is important

--- a/authentication/config.go
+++ b/authentication/config.go
@@ -14,6 +14,10 @@ type Config struct {
 	Environment                      string
 	AuthenticatedAsAServicePrincipal bool
 
+	// A Custom Resource Manager Endpoint
+	// at this time this should only be applicable for Azure Stack.
+	CustomResourceManagerEndpoint string
+
 	authMethod authMethod
 }
 


### PR DESCRIPTION
This exists since this information will be used by Azure Stack.

It's intentionally /not/ scoped to that project since it's required in the Backend too