### PR TITLE
Splitting out the SAS Token Generation

### DIFF
--- a/storage/sas_token.go
+++ b/storage/sas_token.go
@@ -1,0 +1,98 @@
+package storage
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+const (
+	connStringAccountKeyKey  = "AccountKey"
+	connStringAccountNameKey = "AccountName"
+)
+
+// ComputeSASToken computes the SAS Token for a Storage Account based on the
+// access key & given permissions
+func ComputeSASToken(accountName string,
+	accountKey string,
+	permissions string,
+	services string,
+	resourceTypes string,
+	start string,
+	expiry string,
+	signedProtocol string,
+	signedIp string, // nolint: unparam
+	signedVersion string, // nolint: unparam
+) (string, error) {
+
+	// UTF-8 by default...
+	stringToSign := accountName + "\n"
+	stringToSign += permissions + "\n"
+	stringToSign += services + "\n"
+	stringToSign += resourceTypes + "\n"
+	stringToSign += start + "\n"
+	stringToSign += expiry + "\n"
+	stringToSign += signedIp + "\n"
+	stringToSign += signedProtocol + "\n"
+	stringToSign += signedVersion + "\n"
+
+	binaryKey, err := base64.StdEncoding.DecodeString(accountKey)
+	if err != nil {
+		return "", err
+	}
+	hasher := hmac.New(sha256.New, binaryKey)
+	hasher.Write([]byte(stringToSign))
+	signature := hasher.Sum(nil)
+
+	// Trial and error to determine which fields the Azure portal
+	// URL encodes for a query string and which it does not.
+	sasToken := "?sv=" + url.QueryEscape(signedVersion)
+	sasToken += "&ss=" + url.QueryEscape(services)
+	sasToken += "&srt=" + url.QueryEscape(resourceTypes)
+	sasToken += "&sp=" + url.QueryEscape(permissions)
+	sasToken += "&se=" + (expiry)
+	sasToken += "&st=" + (start)
+	sasToken += "&spr=" + (signedProtocol)
+
+	// this is consistent with how the Azure portal builds these.
+	if len(signedIp) > 0 {
+		sasToken += "&sip=" + signedIp
+	}
+
+	sasToken += "&sig=" + url.QueryEscape(base64.StdEncoding.EncodeToString(signature))
+
+	return sasToken, nil
+}
+
+// ParseStorageAccountConnectionString parses the Connection String for a Storage Account
+func ParseStorageAccountConnectionString(connString string) (map[string]string, error) {
+	// This connection string was for a real storage account which has been deleted
+	// so its safe to include here for reference to understand the format.
+	// DefaultEndpointsProtocol=https;AccountName=azurermtestsa0;AccountKey=2vJrjEyL4re2nxCEg590wJUUC7PiqqrDHjAN5RU304FNUQieiEwS2bfp83O0v28iSfWjvYhkGmjYQAdd9x+6nw==;EndpointSuffix=core.windows.net
+	validKeys := map[string]bool{"DefaultEndpointsProtocol": true, "BlobEndpoint": true,
+		"AccountName": true, "AccountKey": true, "EndpointSuffix": true}
+	// The k-v pairs are separated with semi-colons
+	tokens := strings.Split(connString, ";")
+
+	kvp := make(map[string]string)
+
+	for _, atoken := range tokens {
+		// The individual k-v are separated by an equals sign.
+		kv := strings.SplitN(atoken, "=", 2)
+		key := kv[0]
+		val := kv[1]
+		if _, present := validKeys[key]; !present {
+			return nil, fmt.Errorf("[ERROR] Unknown Key: %s", key)
+		}
+		kvp[key] = val
+	}
+
+	if _, present := kvp[connStringAccountKeyKey]; !present {
+		return nil, fmt.Errorf("[ERROR] Storage Account Key not found in connection string: %s", connString)
+	}
+
+	return kvp, nil
+}

--- a/storage/sas_token_test.go
+++ b/storage/sas_token_test.go
@@ -1,0 +1,98 @@
+package storage
+
+import "testing"
+
+func TestParseStorageAccountConnectionString(t *testing.T) {
+	testCases := []struct {
+		input               string
+		expectedAccountName string
+		expectedAccountKey  string
+	}{
+		{
+			"DefaultEndpointsProtocol=https;AccountName=azurermtestsa0;AccountKey=2vJrjEyL4re2nxCEg590wJUUC7PiqqrDHjAN5RU304FNUQieiEwS2bfp83O0v28iSfWjvYhkGmjYQAdd9x+6nw==;EndpointSuffix=core.windows.net",
+			"azurermtestsa0",
+			"2vJrjEyL4re2nxCEg590wJUUC7PiqqrDHjAN5RU304FNUQieiEwS2bfp83O0v28iSfWjvYhkGmjYQAdd9x+6nw==",
+		},
+	}
+
+	for _, test := range testCases {
+		result, err := ParseStorageAccountConnectionString(test.input)
+		if err != nil {
+			t.Fatalf("Failed to parse resource type string: %s, %q", test.input, result)
+		}
+
+		if val, pres := result[connStringAccountKeyKey]; !pres || val != test.expectedAccountKey {
+			t.Fatalf("Failed to parse Account Key: Expected: %s, Found: %s", test.expectedAccountKey, val)
+		}
+		if val, pres := result[connStringAccountNameKey]; !pres || val != test.expectedAccountName {
+			t.Fatalf("Failed to parse Account Name: Expected: %s, Found: %s", test.expectedAccountName, val)
+		}
+	}
+}
+
+// This connection string was for a real storage account which has been deleted
+// so its safe to include here for reference to understand the format.
+// DefaultEndpointsProtocol=https;AccountName=azurermtestsa0;AccountKey=T0ZQouXBDpWud/PlTRHIJH2+VUK8D+fnedEynb9Mx638IYnsMUe4mv1fFjC7t0NayTfFAQJzPZuV1WHFKOzGdg==;EndpointSuffix=core.windows.net
+func TestComputeSASToken(t *testing.T) {
+	testCases := []struct {
+		accountName    string
+		accountKey     string
+		permissions    string
+		services       string
+		resourceTypes  string
+		start          string
+		expiry         string
+		signedProtocol string
+		signedIp       string
+		signedVersion  string
+		knownSasToken  string
+	}{
+		{
+			"azurermtestsa0",
+			"T0ZQouXBDpWud/PlTRHIJH2+VUK8D+fnedEynb9Mx638IYnsMUe4mv1fFjC7t0NayTfFAQJzPZuV1WHFKOzGdg==",
+			"rwac",
+			"b",
+			"c",
+			"2018-03-20T04:00:00Z",
+			"2020-03-20T04:00:00Z",
+			"https",
+			"",
+			"2017-07-29",
+			"?sv=2017-07-29&ss=b&srt=c&sp=rwac&se=2020-03-20T04:00:00Z&st=2018-03-20T04:00:00Z&spr=https&sig=SQigK%2FnFA4pv0F0oMLqr6DxUWV4vtFqWi6q3Mf7o9nY%3D",
+		},
+		{
+			"azurermtestsa0",
+			"2vJrjEyL4re2nxCEg590wJUUC7PiqqrDHjAN5RU304FNUQieiEwS2bfp83O0v28iSfWjvYhkGmjYQAdd9x+6nw==",
+			"rwdlac",
+			"b",
+			"sco",
+			"2018-03-20T04:00:00Z",
+			"2018-03-28T05:04:25Z",
+			"https,http",
+			"",
+			"2017-07-29",
+			"?sv=2017-07-29&ss=b&srt=sco&sp=rwdlac&se=2018-03-28T05:04:25Z&st=2018-03-20T04:00:00Z&spr=https,http&sig=OLNwL%2B7gxeDQQaUyNdXcDPK2aCbCMgEkJNjha9te448%3D",
+		},
+	}
+
+	for _, test := range testCases {
+		computedToken, err := ComputeSASToken(test.accountName,
+			test.accountKey,
+			test.permissions,
+			test.services,
+			test.resourceTypes,
+			test.start,
+			test.expiry,
+			test.signedProtocol,
+			test.signedIp,
+			test.signedVersion)
+
+		if err != nil {
+			t.Fatalf("Test Failed: Error computing storage account Sas: %q", err)
+		}
+
+		if computedToken != test.knownSasToken {
+			t.Fatalf("Test failed: Expected Azure SAS %s but was %s", test.knownSasToken, computedToken)
+		}
+	}
+}


### PR DESCRIPTION
Splitting this out from the AzureRM Repository, since it's needed in the Azure Backend