### PR TITLE
New Auth Method: Azure CLI Tokens

### DIFF
--- a/authentication/auth_method_azure_cli_parsing.go
+++ b/authentication/auth_method_azure_cli_parsing.go
@@ -58,7 +58,6 @@ func (a azureCliParsingAuth) getAuthorizationToken(oauthConfig *adal.OAuthConfig
 	}
 
 	err = spt.Refresh()
-
 	if err != nil {
 		return nil, fmt.Errorf("Error refreshing Service Principal Token: %+v", err)
 	}

--- a/authentication/auth_method_azure_cli_token.go
+++ b/authentication/auth_method_azure_cli_token.go
@@ -1,0 +1,146 @@
+package authentication
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/adal"
+	"github.com/Azure/go-autorest/autorest/azure/cli"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/packer/common/json"
+)
+
+type azureCliTokenAuth struct {
+	profile *azureCLIProfile
+}
+
+func (a azureCliTokenAuth) build(b Builder) (authMethod, error) {
+	auth := azureCliTokenAuth{
+		profile: &azureCLIProfile{
+			clientId:       b.ClientID,
+			environment:    b.Environment,
+			subscriptionId: b.SubscriptionID,
+			tenantId:       b.TenantID,
+		},
+	}
+	profilePath, err := cli.ProfilePath()
+	if err != nil {
+		return nil, fmt.Errorf("Error loading the Profile Path from the Azure CLI: %+v", err)
+	}
+
+	profile, err := cli.LoadProfile(profilePath)
+	if err != nil {
+		return nil, fmt.Errorf("Azure CLI Authorization Profile was not found. Please ensure the Azure CLI is installed and then log-in with `az login`.")
+	}
+
+	auth.profile.profile = profile
+
+	err = auth.profile.populateFields()
+	if err != nil {
+		return nil, err
+	}
+
+	err = auth.profile.populateClientId()
+	if err != nil {
+		return nil, fmt.Errorf("Error populating Client ID from the Azure CLI: %+v", err)
+	}
+
+	return auth, nil
+}
+
+func (a azureCliTokenAuth) isApplicable(b Builder) bool {
+	return b.SupportsAzureCliToken
+}
+
+func (a azureCliTokenAuth) getAuthorizationToken(oauthConfig *adal.OAuthConfig, endpoint string) (*autorest.BearerAuthorizer, error) {
+	// the Azure CLI appears to cache these, so to maintain compatibility with the interface this method is intentionally not on the pointer
+	token, err := obtainAuthorizationToken(endpoint, a.profile.subscriptionId)
+	if err != nil {
+		return nil, fmt.Errorf("Error obtaining Authorization Token from the Azure CLI: %s", err)
+	}
+
+	adalToken, err := token.ToADALToken()
+	if err != nil {
+		return nil, fmt.Errorf("Error converting Authorization Token to an ADAL Token: %s", err)
+	}
+
+	spt, err := adal.NewServicePrincipalTokenFromManualToken(*oauthConfig, a.profile.clientId, endpoint, adalToken)
+	if err != nil {
+		return nil, err
+	}
+
+	auth := autorest.NewBearerAuthorizer(spt)
+	return auth, nil
+}
+
+func (a azureCliTokenAuth) name() string {
+	return "Obtaining a token from the Azure CLI"
+}
+
+func (a azureCliTokenAuth) populateConfig(c *Config) error {
+	c.ClientID = a.profile.clientId
+	c.Environment = a.profile.environment
+	c.SubscriptionID = a.profile.subscriptionId
+	c.TenantID = a.profile.tenantId
+	return nil
+}
+
+func (a azureCliTokenAuth) validate() error {
+	var err *multierror.Error
+
+	errorMessageFmt := "A %s was not found in your Azure CLI Credentials.\n\nPlease login to the Azure CLI again via `az login`"
+
+	if a.profile == nil {
+		return fmt.Errorf("Azure CLI Profile is nil - this is an internal error and should be reported.")
+	}
+
+	if a.profile.clientId == "" {
+		err = multierror.Append(err, fmt.Errorf(errorMessageFmt, "Client ID"))
+	}
+
+	if a.profile.subscriptionId == "" {
+		err = multierror.Append(err, fmt.Errorf(errorMessageFmt, "Subscription ID"))
+	}
+
+	if a.profile.tenantId == "" {
+		err = multierror.Append(err, fmt.Errorf(errorMessageFmt, "Tenant ID"))
+	}
+
+	return err.ErrorOrNil()
+}
+
+func obtainAuthorizationToken(endpoint string, subscriptionId string) (*cli.Token, error) {
+	var stderr bytes.Buffer
+	var stdout bytes.Buffer
+
+	cmd := exec.Command("az", "account", "get-access-token", "--resource", endpoint, "--subscription", subscriptionId, "-o=json")
+
+	cmd.Stderr = &stderr
+	cmd.Stdout = &stdout
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("Error launching Azure CLI: %+v", err)
+	}
+
+	if err := cmd.Wait(); err != nil {
+		return nil, fmt.Errorf("Error waiting for the Azure CLI: %+v", err)
+	}
+
+	stdOutStr := stdout.String()
+	stdErrStr := stderr.String()
+
+	if stdErrStr != "" {
+		return nil, fmt.Errorf("Error retrieving access token from Azure CLI: %s", strings.TrimSpace(stdErrStr))
+	}
+
+	var token *cli.Token
+	err := json.Unmarshal([]byte(stdOutStr), &token)
+	if err != nil {
+		return nil, fmt.Errorf("Error unmarshaling Access Token from the Azure CLI: %s", err)
+	}
+
+	return token, nil
+}

--- a/authentication/auth_method_azure_cli_token_test.go
+++ b/authentication/auth_method_azure_cli_token_test.go
@@ -1,0 +1,140 @@
+package authentication
+
+import (
+	"testing"
+)
+
+func TestAzureCLITokenAuth_isApplicable(t *testing.T) {
+	cases := []struct {
+		Description string
+		Builder     Builder
+		Valid       bool
+	}{
+		{
+			Description: "Empty Configuration",
+			Builder:     Builder{},
+			Valid:       false,
+		},
+		{
+			Description: "Feature Toggled off",
+			Builder: Builder{
+				SupportsAzureCliToken: false,
+			},
+			Valid: false,
+		},
+		{
+			Description: "Feature Toggled on",
+			Builder: Builder{
+				SupportsAzureCliToken: true,
+			},
+			Valid: true,
+		},
+	}
+
+	for _, v := range cases {
+		applicable := azureCliTokenAuth{}.isApplicable(v.Builder)
+		if v.Valid != applicable {
+			t.Fatalf("Expected %q to be %t but got %t", v.Description, v.Valid, applicable)
+		}
+	}
+}
+
+func TestAzureCLITokenAuth_populateConfig(t *testing.T) {
+	config := &Config{}
+	auth := azureCliTokenAuth{
+		profile: &azureCLIProfile{
+			clientId:       "some-subscription-id",
+			environment:    "dimension-c137",
+			subscriptionId: "some-subscription-id",
+			tenantId:       "some-tenant-id",
+		},
+	}
+
+	err := auth.populateConfig(config)
+	if err != nil {
+		t.Fatalf("Error populating config: %s", err)
+	}
+
+	if auth.profile.clientId != config.ClientID {
+		t.Fatalf("Expected Client ID to be %q but got %q", auth.profile.tenantId, config.TenantID)
+	}
+
+	if auth.profile.environment != config.Environment {
+		t.Fatalf("Expected Environment to be %q but got %q", auth.profile.tenantId, config.TenantID)
+	}
+
+	if auth.profile.subscriptionId != config.SubscriptionID {
+		t.Fatalf("Expected Subscription ID to be %q but got %q", auth.profile.tenantId, config.TenantID)
+	}
+
+	if auth.profile.tenantId != config.TenantID {
+		t.Fatalf("Expected Tenant ID to be %q but got %q", auth.profile.tenantId, config.TenantID)
+	}
+}
+
+func TestAzureCLITokenAuth_validate(t *testing.T) {
+	cases := []struct {
+		Description string
+		Config      azureCliTokenAuth
+		ExpectError bool
+	}{
+		{
+			Description: "Empty Configuration",
+			Config:      azureCliTokenAuth{},
+			ExpectError: true,
+		},
+		{
+			Description: "Missing Client ID",
+			Config: azureCliTokenAuth{
+				profile: &azureCLIProfile{
+					subscriptionId: "8e8b5e02-5c13-4822-b7dc-4232afb7e8c2",
+					tenantId:       "9834f8d0-24b3-41b7-8b8d-c611c461a129",
+				},
+			},
+			ExpectError: true,
+		},
+		{
+			Description: "Missing Subscription ID",
+			Config: azureCliTokenAuth{
+				profile: &azureCLIProfile{
+					clientId:    "62e73395-5017-43b6-8ebf-d6c30a514cf1",
+					tenantId:    "9834f8d0-24b3-41b7-8b8d-c611c461a129",
+				},
+			},
+			ExpectError: true,
+		},
+		{
+			Description: "Missing Tenant ID",
+			Config: azureCliTokenAuth{
+				profile: &azureCLIProfile{
+					clientId:       "62e73395-5017-43b6-8ebf-d6c30a514cf1",
+					subscriptionId: "8e8b5e02-5c13-4822-b7dc-4232afb7e8c2",
+				},
+			},
+			ExpectError: true,
+		},
+		{
+			Description: "Valid Configuration",
+			Config: azureCliTokenAuth{
+				profile: &azureCLIProfile{
+					clientId:       "62e73395-5017-43b6-8ebf-d6c30a514cf1",
+					subscriptionId: "8e8b5e02-5c13-4822-b7dc-4232afb7e8c2",
+					tenantId:       "9834f8d0-24b3-41b7-8b8d-c611c461a129",
+				},
+			},
+			ExpectError: false,
+		},
+	}
+
+	for _, v := range cases {
+		err := v.Config.validate()
+
+		if v.ExpectError && err == nil {
+			t.Fatalf("Expected an error for %q: didn't get one", v.Description)
+		}
+
+		if !v.ExpectError && err != nil {
+			t.Fatalf("Expected there to be no error for %q - but got: %v", v.Description, err)
+		}
+	}
+}

--- a/authentication/azure_cli_access_token.go
+++ b/authentication/azure_cli_access_token.go
@@ -15,7 +15,7 @@ type azureCliAccessToken struct {
 	AccessToken  *adal.Token
 }
 
-func findValidAccessTokenForTenant(tokens []cli.Token, tenantId string) (*azureCliAccessToken, error) {
+func findValidAccessTokenForTenant(tokens []cli.Token, tenantId string, allowExpired bool) (*azureCliAccessToken, error) {
 	for _, accessToken := range tokens {
 		token, err := accessToken.ToADALToken()
 		if err != nil {
@@ -27,7 +27,7 @@ func findValidAccessTokenForTenant(tokens []cli.Token, tenantId string) (*azureC
 			return nil, fmt.Errorf("Error parsing expiration date: %q", accessToken.ExpiresOn)
 		}
 
-		if expirationDate.UTC().Before(time.Now().UTC()) {
+		if expirationDate.UTC().Before(time.Now().UTC()) && !allowExpired {
 			log.Printf("[DEBUG] Token %q has expired", token.AccessToken)
 			continue
 		}

--- a/authentication/azure_cli_access_token_test.go
+++ b/authentication/azure_cli_access_token_test.go
@@ -18,7 +18,7 @@ func TestAzureFindValidAccessTokenForTenant_InvalidDate(t *testing.T) {
 		Authority:    tenantId,
 	}
 	tokens := []cli.Token{expectedToken}
-	token, err := findValidAccessTokenForTenant(tokens, tenantId)
+	token, err := findValidAccessTokenForTenant(tokens, tenantId, false)
 
 	if err == nil {
 		t.Fatalf("Expected an error to be returned but got nil")
@@ -41,7 +41,7 @@ func TestAzureFindValidAccessTokenForTenant_Expired(t *testing.T) {
 		Authority:    tenantId,
 	}
 	tokens := []cli.Token{expectedToken}
-	token, err := findValidAccessTokenForTenant(tokens, tenantId)
+	token, err := findValidAccessTokenForTenant(tokens, tenantId, false)
 
 	if err == nil {
 		t.Fatalf("Expected an error to be returned but got nil")
@@ -49,6 +49,29 @@ func TestAzureFindValidAccessTokenForTenant_Expired(t *testing.T) {
 
 	if token != nil {
 		t.Fatalf("Expected Token to be nil but got: %+v", token)
+	}
+}
+
+func TestAzureFindValidAccessTokenForTenant_ExpiredAllowingExpiredToken(t *testing.T) {
+	expirationDate := time.Now().Add(time.Minute * -1)
+	tenantId := "c056adac-c6a6-4ddf-ab20-0f26d47f7eea"
+	expectedToken := cli.Token{
+		ExpiresOn:    expirationDate.Format("2006-01-02 15:04:05.999999"),
+		AccessToken:  "7cabcf30-8dca-43f9-91e6-fd56dfb8632f",
+		TokenType:    "9b10b986-7a61-4542-8d5a-9fcd96112585",
+		RefreshToken: "4ec3874d-ee2e-4980-ba47-b5bac11ddb94",
+		Resource:     "https://management.core.windows.net/",
+		Authority:    tenantId,
+	}
+	tokens := []cli.Token{expectedToken}
+	token, err := findValidAccessTokenForTenant(tokens, tenantId, true)
+
+	if err != nil {
+		t.Fatalf("Expected no error to be returned but got: %+v", err)
+	}
+
+	if token == nil {
+		t.Fatalf("Expected Token to not be nil but got: %+v", token)
 	}
 }
 
@@ -67,7 +90,7 @@ func TestAzureFindValidAccessTokenForTenant_ExpiringIn(t *testing.T) {
 			Authority:    tenantId,
 		}
 		tokens := []cli.Token{expectedToken}
-		token, err := findValidAccessTokenForTenant(tokens, tenantId)
+		token, err := findValidAccessTokenForTenant(tokens, tenantId, false)
 
 		if err != nil {
 			t.Fatalf("Expected no error to be returned for minute %d but got %+v", minute, err)
@@ -98,7 +121,7 @@ func TestAzureFindValidAccessTokenForTenant_InvalidManagementDomain(t *testing.T
 		Authority:   tenantId,
 	}
 	tokens := []cli.Token{expectedToken}
-	token, err := findValidAccessTokenForTenant(tokens, tenantId)
+	token, err := findValidAccessTokenForTenant(tokens, tenantId, false)
 
 	if err == nil {
 		t.Fatalf("Expected an error but didn't get one")
@@ -119,7 +142,7 @@ func TestAzureFindValidAccessTokenForTenant_DifferentTenant(t *testing.T) {
 		Authority:   "9b5095de-5496-4b5e-9bc6-ef2c017b9d35",
 	}
 	tokens := []cli.Token{expectedToken}
-	token, err := findValidAccessTokenForTenant(tokens, "c056adac-c6a6-4ddf-ab20-0f26d47f7eea")
+	token, err := findValidAccessTokenForTenant(tokens, "c056adac-c6a6-4ddf-ab20-0f26d47f7eea", false)
 
 	if err == nil {
 		t.Fatalf("Expected an error but didn't get one")
@@ -142,7 +165,7 @@ func TestAzureFindValidAccessTokenForTenant_Valid(t *testing.T) {
 		Authority:    tenantId,
 	}
 	tokens := []cli.Token{expectedToken}
-	token, err := findValidAccessTokenForTenant(tokens, tenantId)
+	token, err := findValidAccessTokenForTenant(tokens, tenantId, false)
 
 	if err != nil {
 		t.Fatalf("Expected no error to be returned but got %+v", err)
@@ -163,7 +186,7 @@ func TestAzureFindValidAccessTokenForTenant_Valid(t *testing.T) {
 
 func TestAzureFindValidAccessTokenForTenant_NoTokens(t *testing.T) {
 	tokens := make([]cli.Token, 0)
-	token, err := findValidAccessTokenForTenant(tokens, "abc123")
+	token, err := findValidAccessTokenForTenant(tokens, "abc123", false)
 
 	if err == nil {
 		t.Fatalf("Expected an error but didn't get one")

--- a/authentication/azure_cli_profile.go
+++ b/authentication/azure_cli_profile.go
@@ -32,12 +32,6 @@ func (a *azureCLIProfile) populateFields() error {
 		}
 	}
 
-	// now we know the Subscription ID & Tenant ID we can find the associated Client ID/Access Token
-	err := a.populateClientIdAndAccessToken()
-	if err != nil {
-		return err
-	}
-
 	// always pull the environment from the Azure CLI, since the Access Token's associated with it
 	return a.populateEnvironment()
 }

--- a/authentication/azure_cli_profile_population.go
+++ b/authentication/azure_cli_profile_population.go
@@ -46,7 +46,6 @@ func (a *azureCLIProfile) populateClientId() error {
 
 	token := *validToken
 	a.clientId = token.ClientID
-	a.usingCloudShell = token.IsCloudShell
 
 	return nil
 }

--- a/authentication/azure_cli_profile_population.go
+++ b/authentication/azure_cli_profile_population.go
@@ -27,6 +27,30 @@ func (a *azureCLIProfile) populateTenantID() error {
 	return nil
 }
 
+func (a *azureCLIProfile) populateClientId() error {
+	// we can now pull out the ClientID and the Access Token to use from the Access Token
+	tokensPath, err := cli.AccessTokensPath()
+	if err != nil {
+		return fmt.Errorf("Error loading the Tokens Path from the Azure CLI: %+v", err)
+	}
+
+	tokens, err := cli.LoadTokens(tokensPath)
+	if err != nil {
+		return fmt.Errorf("No Authorization Tokens were found - please ensure the Azure CLI is installed and then log-in with `az login`.")
+	}
+
+	validToken, err := findValidAccessTokenForTenant(tokens, a.tenantId, true)
+	if err != nil {
+		return fmt.Errorf("No Authorization Tokens were found - please re-authenticate using `az login`.")
+	}
+
+	token := *validToken
+	a.clientId = token.ClientID
+	a.usingCloudShell = token.IsCloudShell
+
+	return nil
+}
+
 func (a *azureCLIProfile) populateClientIdAndAccessToken() error {
 	// we can now pull out the ClientID and the Access Token to use from the Access Token
 	tokensPath, err := cli.AccessTokensPath()
@@ -39,7 +63,7 @@ func (a *azureCLIProfile) populateClientIdAndAccessToken() error {
 		return fmt.Errorf("No Authorization Tokens were found - please ensure the Azure CLI is installed and then log-in with `az login`.")
 	}
 
-	validToken, err := findValidAccessTokenForTenant(tokens, a.tenantId)
+	validToken, err := findValidAccessTokenForTenant(tokens, a.tenantId, false)
 	if err != nil {
 		return fmt.Errorf("No (unexpired) Authorization Tokens were found - please re-authenticate using `az login`.")
 	}

--- a/authentication/builder.go
+++ b/authentication/builder.go
@@ -21,6 +21,9 @@ type Builder struct {
 	// Azure CLI Parsing
 	SupportsAzureCliParsing bool
 
+	// Azure CLI Tokens Auth
+	SupportsAzureCliToken bool
+
 	// Managed Service Identity Auth
 	SupportsManagedServiceIdentity bool
 	MsiEndpoint                    string
@@ -52,6 +55,7 @@ func (b Builder) Build() (*Config, error) {
 		servicePrincipalClientCertificateAuth{},
 		servicePrincipalClientSecretAuth{},
 		managedServiceIdentityAuth{},
+		azureCliTokenAuth{},
 		azureCliParsingAuth{},
 	}
 


### PR DESCRIPTION
This PR introduces a new authentication method: authenticating using the Azure CLI by obtaining an Access Token.

The intention is that this'd replace the existing Azure CLI Parsing authentication method, such that we now delegate to the Azure CLI to obtain the token. ~Once this PR's merged I think it'd be sensible to split CloudShell out into it's own auth method, so that we can remove the older Azure CLI Parsing authentication method in the future.~ CloudShell's using MSI - so I guess we can just outright remove the Azure CLI Parsing functionality once this is merged

Since we're not relying on retrieving the Access Token, this fixes https://github.com/terraform-providers/terraform-provider-azurerm/pull/1752 and fixes #4