### PR TITLE
[WIP] New Auth Method: CloudShell

### DIFF
--- a/authentication/auth_method_cloudshell.go
+++ b/authentication/auth_method_cloudshell.go
@@ -1,0 +1,109 @@
+package authentication
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/adal"
+	"github.com/Azure/go-autorest/autorest/azure/cli"
+	"github.com/hashicorp/go-multierror"
+)
+
+type cloudShellAuth struct {
+	profile *azureCLIProfile
+}
+
+func (a cloudShellAuth) build(b Builder) (authMethod, error) {
+	auth := cloudShellAuth{
+		profile: &azureCLIProfile{
+			clientId:       b.ClientID,
+			environment:    b.Environment,
+			subscriptionId: b.SubscriptionID,
+			tenantId:       b.TenantID,
+		},
+	}
+	profilePath, err := cli.ProfilePath()
+	if err != nil {
+		return nil, fmt.Errorf("Error loading the Azure CLI Profile Path from CloudShell: %+v", err)
+	}
+
+	profile, err := cli.LoadProfile(profilePath)
+	if err != nil {
+		return nil, fmt.Errorf("Azure CLI Authorization Profile was not found. Please re-launch your CloudShell.")
+	}
+
+	auth.profile.profile = profile
+
+	err = auth.profile.populateFields()
+	if err != nil {
+		return nil, err
+	}
+
+	err = auth.profile.populateClientIdAndAccessToken()
+	if err != nil {
+		return nil, fmt.Errorf("Error populating CloudShell Access Tokens from the Azure CLI: %+v", err)
+	}
+
+	return auth, nil
+}
+
+func (a cloudShellAuth) isApplicable(b Builder) bool {
+	return b.SupportsCloudShell && os.Getenv("ACC_CLOUD") != ""
+}
+
+func (a cloudShellAuth) getAuthorizationToken(oauthConfig *adal.OAuthConfig, endpoint string) (*autorest.BearerAuthorizer, error) {
+	// load the refreshed tokens from the CloudShell Azure CLI credentials
+	err := a.profile.populateClientIdAndAccessToken()
+	if err != nil {
+		return nil, fmt.Errorf("Error loading the refreshed CloudShell tokens: %+v", err)
+	}
+
+	spt, err := adal.NewServicePrincipalTokenFromManualToken(*oauthConfig, a.profile.clientId, endpoint, *a.profile.accessToken)
+	if err != nil {
+		return nil, err
+	}
+
+	auth := autorest.NewBearerAuthorizer(spt)
+	return auth, nil
+}
+
+func (a cloudShellAuth) name() string {
+	return "Parsing credentials from CloudShell"
+}
+
+func (a cloudShellAuth) populateConfig(c *Config) error {
+	c.ClientID = a.profile.clientId
+	c.Environment = a.profile.environment
+	c.SubscriptionID = a.profile.subscriptionId
+	c.TenantID = a.profile.tenantId
+	return nil
+}
+
+func (a cloudShellAuth) validate() error {
+	var err *multierror.Error
+
+	errorMessageFmt := "A %s was not found in your Azure CLI Credentials.\n\nPlease re-launch your CloudShell."
+
+	if a.profile == nil {
+		return fmt.Errorf("Azure CLI Profile is nil - this is an internal error and should be reported.")
+	}
+
+	if a.profile.accessToken == nil {
+		err = multierror.Append(err, fmt.Errorf(errorMessageFmt, "Access Token"))
+	}
+
+	if a.profile.clientId == "" {
+		err = multierror.Append(err, fmt.Errorf(errorMessageFmt, "Client ID"))
+	}
+
+	if a.profile.subscriptionId == "" {
+		err = multierror.Append(err, fmt.Errorf(errorMessageFmt, "Subscription ID"))
+	}
+
+	if a.profile.tenantId == "" {
+		err = multierror.Append(err, fmt.Errorf(errorMessageFmt, "Tenant ID"))
+	}
+
+	return err.ErrorOrNil()
+}

--- a/authentication/auth_method_cloudshell_test.go
+++ b/authentication/auth_method_cloudshell_test.go
@@ -1,0 +1,185 @@
+package authentication
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Azure/go-autorest/autorest/adal"
+)
+
+func TestCloudShellAuth_isApplicable(t *testing.T) {
+	cases := []struct {
+		Description string
+		Builder     Builder
+		SetEnvVar   bool
+		Valid       bool
+	}{
+		{
+			Description: "Empty Configuration",
+			Builder:     Builder{},
+			SetEnvVar:   false,
+			Valid:       false,
+		},
+		{
+			Description: "Feature Toggled off",
+			Builder: Builder{
+				SupportsCloudShell: false,
+			},
+			SetEnvVar: false,
+			Valid:     false,
+		},
+		{
+			Description: "Feature Toggled off with environment variable",
+			Builder: Builder{
+				SupportsCloudShell: false,
+			},
+			SetEnvVar: true,
+			Valid:     false,
+		},
+		{
+			Description: "Feature Toggled on but no environment variable",
+			Builder: Builder{
+				SupportsCloudShell: true,
+			},
+			SetEnvVar: false,
+			Valid:     false,
+		},
+		{
+			Description: "Feature Toggled on with environment variable",
+			Builder: Builder{
+				SupportsCloudShell: true,
+			},
+			SetEnvVar: true,
+			Valid:     true,
+		},
+	}
+
+	for _, v := range cases {
+		// simulate running within CloudShell
+		if v.SetEnvVar {
+			os.Setenv("ACC_CLOUD", "PROD")
+		} else {
+			os.Unsetenv("ACC_CLOUD")
+		}
+
+		applicable := cloudShellAuth{}.isApplicable(v.Builder)
+		if v.Valid != applicable {
+			t.Fatalf("Expected %q to be %t but got %t", v.Description, v.Valid, applicable)
+		}
+	}
+}
+
+func TestCloudShellAuth_populateConfig(t *testing.T) {
+	config := &Config{}
+	auth := cloudShellAuth{
+		profile: &azureCLIProfile{
+			clientId:       "some-subscription-id",
+			environment:    "dimension-c137",
+			subscriptionId: "some-subscription-id",
+			tenantId:       "some-tenant-id",
+		},
+	}
+
+	err := auth.populateConfig(config)
+	if err != nil {
+		t.Fatalf("Error populating config: %s", err)
+	}
+
+	if auth.profile.clientId != config.ClientID {
+		t.Fatalf("Expected Client ID to be %q but got %q", auth.profile.tenantId, config.TenantID)
+	}
+
+	if auth.profile.environment != config.Environment {
+		t.Fatalf("Expected Environment to be %q but got %q", auth.profile.tenantId, config.TenantID)
+	}
+
+	if auth.profile.subscriptionId != config.SubscriptionID {
+		t.Fatalf("Expected Subscription ID to be %q but got %q", auth.profile.tenantId, config.TenantID)
+	}
+
+	if auth.profile.tenantId != config.TenantID {
+		t.Fatalf("Expected Tenant ID to be %q but got %q", auth.profile.tenantId, config.TenantID)
+	}
+}
+
+func TestCloudShellAuth_validate(t *testing.T) {
+	cases := []struct {
+		Description string
+		Config      cloudShellAuth
+		ExpectError bool
+	}{
+		{
+			Description: "Empty Configuration",
+			Config:      cloudShellAuth{},
+			ExpectError: true,
+		},
+		{
+			Description: "Missing Access Token",
+			Config: cloudShellAuth{
+				profile: &azureCLIProfile{
+					clientId:       "62e73395-5017-43b6-8ebf-d6c30a514cf1",
+					subscriptionId: "8e8b5e02-5c13-4822-b7dc-4232afb7e8c2",
+					tenantId:       "9834f8d0-24b3-41b7-8b8d-c611c461a129",
+				},
+			},
+			ExpectError: true,
+		},
+		{
+			Description: "Missing Client ID",
+			Config: cloudShellAuth{
+				profile: &azureCLIProfile{
+					accessToken:    &adal.Token{},
+					subscriptionId: "8e8b5e02-5c13-4822-b7dc-4232afb7e8c2",
+					tenantId:       "9834f8d0-24b3-41b7-8b8d-c611c461a129",
+				},
+			},
+			ExpectError: true,
+		},
+		{
+			Description: "Missing Subscription ID",
+			Config: cloudShellAuth{
+				profile: &azureCLIProfile{
+					accessToken: &adal.Token{},
+					clientId:    "62e73395-5017-43b6-8ebf-d6c30a514cf1",
+					tenantId:    "9834f8d0-24b3-41b7-8b8d-c611c461a129",
+				},
+			},
+			ExpectError: true,
+		},
+		{
+			Description: "Missing Tenant ID",
+			Config: cloudShellAuth{
+				profile: &azureCLIProfile{
+					accessToken:    &adal.Token{},
+					clientId:       "62e73395-5017-43b6-8ebf-d6c30a514cf1",
+					subscriptionId: "8e8b5e02-5c13-4822-b7dc-4232afb7e8c2",
+				},
+			},
+			ExpectError: true,
+		},
+		{
+			Description: "Valid Configuration",
+			Config: cloudShellAuth{
+				profile: &azureCLIProfile{
+					accessToken:    &adal.Token{},
+					clientId:       "62e73395-5017-43b6-8ebf-d6c30a514cf1",
+					subscriptionId: "8e8b5e02-5c13-4822-b7dc-4232afb7e8c2",
+					tenantId:       "9834f8d0-24b3-41b7-8b8d-c611c461a129",
+				},
+			},
+			ExpectError: false,
+		},
+	}
+
+	for _, v := range cases {
+		err := v.Config.validate()
+
+		if v.ExpectError && err == nil {
+			t.Fatalf("Expected an error for %q: didn't get one", v.Description)
+		}
+
+		if !v.ExpectError && err != nil {
+			t.Fatalf("Expected there to be no error for %q - but got: %v", v.Description, err)
+		}
+	}
+}

--- a/authentication/builder.go
+++ b/authentication/builder.go
@@ -21,6 +21,9 @@ type Builder struct {
 	// Azure CLI Parsing / CloudShell Auth
 	SupportsAzureCliCloudShellParsing bool
 
+	// CloudShell Auth
+	SupportsCloudShell bool
+
 	// Managed Service Identity Auth
 	SupportsManagedServiceIdentity bool
 	MsiEndpoint                    string
@@ -52,6 +55,8 @@ func (b Builder) Build() (*Config, error) {
 		servicePrincipalClientCertificateAuth{},
 		servicePrincipalClientSecretAuth{},
 		managedServiceIdentityAuth{},
+		cloudShellAuth{},
+		// TODO: deprecate support for Azure CLI Parsing auth
 		azureCliParsingAuth{},
 	}
 


### PR DESCRIPTION
This PR adds a new authentication method specifically for CloudShell - which should allow us to deprecate the existing Azure CLI Parsing Auth.

This is mostly a duplication of the Azure CLI Parsing Auth at this point, with the notable exception that it assumes we're running in CloudShell.

Once this has been released we should be able to remove support for the Azure CLI Parsing Auth.