### PR TITLE
Removing CloudShell

### DIFF
--- a/authentication/auth_method_azure_cli_parsing.go
+++ b/authentication/auth_method_azure_cli_parsing.go
@@ -52,14 +52,6 @@ func (a azureCliParsingAuth) isApplicable(b Builder) bool {
 }
 
 func (a azureCliParsingAuth) getAuthorizationToken(oauthConfig *adal.OAuthConfig, endpoint string) (*autorest.BearerAuthorizer, error) {
-	if a.profile.usingCloudShell {
-		// load the refreshed tokens from the CloudShell Azure CLI credentials
-		err := a.profile.populateClientIdAndAccessToken()
-		if err != nil {
-			return nil, fmt.Errorf("Error loading the refreshed CloudShell tokens: %+v", err)
-		}
-	}
-
 	spt, err := adal.NewServicePrincipalTokenFromManualToken(*oauthConfig, a.profile.clientId, endpoint, *a.profile.accessToken)
 	if err != nil {
 		return nil, err

--- a/authentication/auth_method_azure_cli_parsing.go
+++ b/authentication/auth_method_azure_cli_parsing.go
@@ -48,7 +48,7 @@ func (a azureCliParsingAuth) build(b Builder) (authMethod, error) {
 }
 
 func (a azureCliParsingAuth) isApplicable(b Builder) bool {
-	return b.SupportsAzureCliCloudShellParsing
+	return b.SupportsAzureCliParsing
 }
 
 func (a azureCliParsingAuth) getAuthorizationToken(oauthConfig *adal.OAuthConfig, endpoint string) (*autorest.BearerAuthorizer, error) {

--- a/authentication/auth_method_azure_cli_parsing_test.go
+++ b/authentication/auth_method_azure_cli_parsing_test.go
@@ -20,14 +20,14 @@ func TestAzureCLIParsingAuth_isApplicable(t *testing.T) {
 		{
 			Description: "Feature Toggled off",
 			Builder: Builder{
-				SupportsAzureCliCloudShellParsing: false,
+				SupportsAzureCliParsing: false,
 			},
 			Valid: false,
 		},
 		{
 			Description: "Feature Toggled on",
 			Builder: Builder{
-				SupportsAzureCliCloudShellParsing: true,
+				SupportsAzureCliParsing: true,
 			},
 			Valid: true,
 		},

--- a/authentication/azure_cli_access_token.go
+++ b/authentication/azure_cli_access_token.go
@@ -13,7 +13,6 @@ import (
 type azureCliAccessToken struct {
 	ClientID     string
 	AccessToken  *adal.Token
-	IsCloudShell bool
 }
 
 func findValidAccessTokenForTenant(tokens []cli.Token, tenantId string) (*azureCliAccessToken, error) {
@@ -46,7 +45,6 @@ func findValidAccessTokenForTenant(tokens []cli.Token, tenantId string) (*azureC
 		validAccessToken := azureCliAccessToken{
 			ClientID:     accessToken.ClientID,
 			AccessToken:  &token,
-			IsCloudShell: accessToken.RefreshToken == "",
 		}
 		return &validAccessToken, nil
 	}

--- a/authentication/azure_cli_access_token_test.go
+++ b/authentication/azure_cli_access_token_test.go
@@ -84,10 +84,6 @@ func TestAzureFindValidAccessTokenForTenant_ExpiringIn(t *testing.T) {
 		if token.ClientID != expectedToken.ClientID {
 			t.Fatalf("Expected the Client ID to be %q for minute %d but got %q", expectedToken.ClientID, minute, token.ClientID)
 		}
-
-		if token.IsCloudShell {
-			t.Fatalf("Expected `IsCloudShell` to be false for minute %d but got true", minute)
-		}
 	}
 }
 
@@ -134,41 +130,7 @@ func TestAzureFindValidAccessTokenForTenant_DifferentTenant(t *testing.T) {
 	}
 }
 
-func TestAzureFindValidAccessTokenForTenant_ValidFromCloudShell(t *testing.T) {
-	expirationDate := time.Now().Add(1 * time.Hour)
-	tenantId := "c056adac-c6a6-4ddf-ab20-0f26d47f7eea"
-	expectedToken := cli.Token{
-		ExpiresOn:   expirationDate.Format(time.RFC3339),
-		AccessToken: "7cabcf30-8dca-43f9-91e6-fd56dfb8632f",
-		TokenType:   "9b10b986-7a61-4542-8d5a-9fcd96112585",
-		Resource:    "https://management.core.windows.net/",
-		Authority:   tenantId,
-	}
-	tokens := []cli.Token{expectedToken}
-	token, err := findValidAccessTokenForTenant(tokens, tenantId)
-
-	if err != nil {
-		t.Fatalf("Expected no error to be returned but got %+v", err)
-	}
-
-	if token == nil {
-		t.Fatalf("Expected Token to have a value but it was nil")
-	}
-
-	if token.AccessToken.AccessToken != expectedToken.AccessToken {
-		t.Fatalf("Expected the Access Token to be %q but got %q", expectedToken.AccessToken, token.AccessToken.AccessToken)
-	}
-
-	if token.ClientID != expectedToken.ClientID {
-		t.Fatalf("Expected the Client ID to be %q but got %q", expectedToken.ClientID, token.ClientID)
-	}
-
-	if !token.IsCloudShell {
-		t.Fatalf("Expected `IsCloudShell` to be true but got false")
-	}
-}
-
-func TestAzureFindValidAccessTokenForTenant_ValidFromAzureCLI(t *testing.T) {
+func TestAzureFindValidAccessTokenForTenant_Valid(t *testing.T) {
 	expirationDate := time.Now().Add(1 * time.Hour)
 	tenantId := "c056adac-c6a6-4ddf-ab20-0f26d47f7eea"
 	expectedToken := cli.Token{
@@ -196,10 +158,6 @@ func TestAzureFindValidAccessTokenForTenant_ValidFromAzureCLI(t *testing.T) {
 
 	if token.ClientID != expectedToken.ClientID {
 		t.Fatalf("Expected the Client ID to be %q but got %q", expectedToken.ClientID, token.ClientID)
-	}
-
-	if token.IsCloudShell {
-		t.Fatalf("Expected `IsCloudShell` to be false but got true")
 	}
 }
 

--- a/authentication/azure_cli_profile.go
+++ b/authentication/azure_cli_profile.go
@@ -13,7 +13,6 @@ type azureCLIProfile struct {
 	subscriptionId  string
 	tenantId        string
 	accessToken     *adal.Token
-	usingCloudShell bool
 }
 
 func (a *azureCLIProfile) populateFields() error {

--- a/authentication/azure_cli_profile_population.go
+++ b/authentication/azure_cli_profile_population.go
@@ -47,7 +47,6 @@ func (a *azureCLIProfile) populateClientIdAndAccessToken() error {
 	token := *validToken
 	a.accessToken = token.AccessToken
 	a.clientId = token.ClientID
-	a.usingCloudShell = token.IsCloudShell
 
 	return nil
 }

--- a/authentication/builder.go
+++ b/authentication/builder.go
@@ -18,8 +18,8 @@ type Builder struct {
 	// only applicable for Azure Stack at this time.
 	CustomResourceManagerEndpoint string
 
-	// Azure CLI Parsing / CloudShell Auth
-	SupportsAzureCliCloudShellParsing bool
+	// Azure CLI Parsing
+	SupportsAzureCliParsing bool
 
 	// Managed Service Identity Auth
 	SupportsManagedServiceIdentity bool


### PR DESCRIPTION
Apparently [at some point CloudShell switched to using MSI](https://github.com/hashicorp/go-azure-helpers/pull/10#issuecomment-441281892) for authenticating which means this code is no longer needed.

This is technically a breaking change, so I guess we'll release this and #9 as 0.2.0