### PR TITLE
Renaming the storage methods to `account sas` since they're account specific

### DIFF
--- a/storage/sas_token.go
+++ b/storage/sas_token.go
@@ -14,9 +14,9 @@ const (
 	connStringAccountNameKey = "AccountName"
 )
 
-// ComputeSASToken computes the SAS Token for a Storage Account based on the
+// ComputeAccountSASToken computes the SAS Token for a Storage Account based on the
 // access key & given permissions
-func ComputeSASToken(accountName string,
+func ComputeAccountSASToken(accountName string,
 	accountKey string,
 	permissions string,
 	services string,
@@ -67,8 +67,8 @@ func ComputeSASToken(accountName string,
 	return sasToken, nil
 }
 
-// ParseStorageAccountConnectionString parses the Connection String for a Storage Account
-func ParseStorageAccountConnectionString(connString string) (map[string]string, error) {
+// ParseAccountSASConnectionString parses the Connection String for a Storage Account
+func ParseAccountSASConnectionString(connString string) (map[string]string, error) {
 	// This connection string was for a real storage account which has been deleted
 	// so its safe to include here for reference to understand the format.
 	// DefaultEndpointsProtocol=https;AccountName=azurermtestsa0;AccountKey=2vJrjEyL4re2nxCEg590wJUUC7PiqqrDHjAN5RU304FNUQieiEwS2bfp83O0v28iSfWjvYhkGmjYQAdd9x+6nw==;EndpointSuffix=core.windows.net

--- a/storage/sas_token_test.go
+++ b/storage/sas_token_test.go
@@ -16,7 +16,7 @@ func TestParseStorageAccountConnectionString(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		result, err := ParseStorageAccountConnectionString(test.input)
+		result, err := ParseAccountSASConnectionString(test.input)
 		if err != nil {
 			t.Fatalf("Failed to parse resource type string: %s, %q", test.input, result)
 		}
@@ -76,7 +76,7 @@ func TestComputeSASToken(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		computedToken, err := ComputeSASToken(test.accountName,
+		computedToken, err := ComputeAccountSASToken(test.accountName,
 			test.accountKey,
 			test.permissions,
 			test.services,


### PR DESCRIPTION
As discussed in https://github.com/terraform-providers/terraform-provider-azurerm/pull/2376/files/523e5cd3b44c7670c01a77e8d8b75dcd11ac8c2e#diff-4f43aaf43e47b471f8029af4c719ecc6