### PR TITLE
prevent panic in ParseAccountSASConnectionString

### DIFF
--- a/storage/sas_token.go
+++ b/storage/sas_token.go
@@ -82,10 +82,15 @@ func ParseAccountSASConnectionString(connString string) (map[string]string, erro
 	for _, atoken := range tokens {
 		// The individual k-v are separated by an equals sign.
 		kv := strings.SplitN(atoken, "=", 2)
+		if len(kv) != 2 {
+			return nil, fmt.Errorf("[ERROR] token `%s` is an invlaid key=pair (connection string %s)", atoken, connString)
+		}
+
 		key := kv[0]
 		val := kv[1]
+
 		if _, present := validKeys[key]; !present {
-			return nil, fmt.Errorf("[ERROR] Unknown Key: %s", key)
+			return nil, fmt.Errorf("[ERROR] Unknown Key `%s` in connection string %s", key, connString)
 		}
 		kvp[key] = val
 	}

--- a/storage/sas_token_test.go
+++ b/storage/sas_token_test.go
@@ -7,17 +7,33 @@ func TestParseStorageAccountConnectionString(t *testing.T) {
 		input               string
 		expectedAccountName string
 		expectedAccountKey  string
+		expectedError       bool
 	}{
 		{
 			"DefaultEndpointsProtocol=https;AccountName=azurermtestsa0;AccountKey=2vJrjEyL4re2nxCEg590wJUUC7PiqqrDHjAN5RU304FNUQieiEwS2bfp83O0v28iSfWjvYhkGmjYQAdd9x+6nw==;EndpointSuffix=core.windows.net",
 			"azurermtestsa0",
 			"2vJrjEyL4re2nxCEg590wJUUC7PiqqrDHjAN5RU304FNUQieiEwS2bfp83O0v28iSfWjvYhkGmjYQAdd9x+6nw==",
+			false,
+		},
+		{
+			"DefaultEndpointsProtocol=https;AccountName=azurermtestsa0;AccountKey=2vJrjEyL4re2nxCEg590wJUUC7PiqqrDHjAN5RU304FNUQieiEwS2bfp83O0v28iSfWjvYhkGmjYQAdd9x+6nw==;EndpointSuffix",
+			"",
+			"",
+			true,
 		},
 	}
 
 	for _, test := range testCases {
 		result, err := ParseAccountSASConnectionString(test.input)
-		if err != nil {
+
+		if test.expectedError {
+			if err == nil {
+				t.Fatalf("Expected error for %s: %q", test.input, err)
+			}
+			return
+		}
+
+		if ! test.expectedError && err != nil {
 			t.Fatalf("Failed to parse resource type string: %s, %q", test.input, result)
 		}
 


### PR DESCRIPTION
fix for [azure #2465](https://github.com/terraform-providers/terraform-provider-azurerm/issues/2465) panic:

```
2018-12-06T18:45:56.774+0100 [DEBUG] plugin.terraform-provider-azurerm_v1.19.0_x4: panic: runtime error: index out of range
2018-12-06T18:45:56.774+0100 [DEBUG] plugin.terraform-provider-azurerm_v1.19.0_x4: 
2018-12-06T18:45:56.774+0100 [DEBUG] plugin.terraform-provider-azurerm_v1.19.0_x4: goroutine 87 [running]:
2018-12-06T18:45:56.774+0100 [DEBUG] plugin.terraform-provider-azurerm_v1.19.0_x4: github.com/terraform-providers/terraform-provider-azurerm/azurerm.parseAzureStorageAccountConnectionString(0xc000390a00, 0x45, 0x8, 0x4, 0xc0009abde8)
2018-12-06T18:45:56.774+0100 [DEBUG] plugin.terraform-provider-azurerm_v1.19.0_x4:      /opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-azurerm/azurerm/data_source_storage_account_sas.go:378 +0x55f
2018-12-06T18:45:56.774+0100 [DEBUG] plugin.terraform-provider-azurerm_v1.19.0_x4: github.com/terraform-providers/terraform-provider-azurerm/azurerm.dataSourceArmStorageAccountSasRead(0xc0007628c0, 0x2156020, 0xc0006ae000, 0xc0007628c0, 0x0)
2018-12-06T18:45:56.774+0100 [DEBUG] plugin.terraform-provider-azurerm_v1.19.0_x4:      /opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-azurerm/azurerm/data_source_storage_account_sas.go:202 +0x6b9
2018-12-06T18:45:56.774+0100 [DEBUG] plugin.terraform-provider-azurerm_v1.19.0_x4: github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema.(*Resource).ReadDataApply(0xc000595340, 0xc0007b7d00, 0x2156020, 0xc0006ae000, 0xc000097058, 0x4c2201, 0x1dfbaa0)
2018-12-06T18:45:56.774+0100 [DEBUG] plugin.terraform-provider-azurerm_v1.19.0_x4:      /opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema/resource.go:290 +0x88
2018-12-06T18:45:56.774+0100 [DEBUG] plugin.terraform-provider-azurerm_v1.19.0_x4: github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema.(*Provider).ReadDataApply(0xc0004f10a0, 0xc00068c320, 0xc0007b7d00, 0xc00006c380, 0x18, 0x7f6c9f85f440)
2018-12-06T18:45:56.774+0100 [DEBUG] plugin.terraform-provider-azurerm_v1.19.0_x4:      /opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema/provider.go:426 +0x92
2018-12-06T18:45:56.774+0100 [DEBUG] plugin.terraform-provider-azurerm_v1.19.0_x4: github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/plugin.(*ResourceProviderServer).ReadDataApply(0xc0002df760, 0xc0004684a0, 0xc0004684d0, 0x0, 0x0)
2018-12-06T18:45:56.774+0100 [DEBUG] plugin.terraform-provider-azurerm_v1.19.0_x4:      /opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/plugin/resource_provider.go:604 +0x4e
2018-12-06T18:45:56.774+0100 [DEBUG] plugin.terraform-provider-azurerm_v1.19.0_x4: reflect.Value.call(0xc00057aa80, 0xc00000c0f0, 0x13, 0x218cf71, 0x4, 0xc000828f18, 0x3, 0x3, 0xc000178300, 0x0, ...)
2018-12-06T18:45:56.774+0100 [DEBUG] plugin.terraform-provider-azurerm_v1.19.0_x4:      /opt/goenv/versions/1.11.1/src/reflect/value.go:447 +0x449
2018-12-06T18:45:56.774+0100 [DEBUG] plugin.terraform-provider-azurerm_v1.19.0_x4: reflect.Value.Call(0xc00057aa80, 0xc00000c0f0, 0x13, 0xc000065f18, 0x3, 0x3, 0x0, 0x0, 0x0)
2018-12-06T18:45:56.774+0100 [DEBUG] plugin.terraform-provider-azurerm_v1.19.0_x4:      /opt/goenv/versions/1.11.1/src/reflect/value.go:308 +0xa4
2018-12-06T18:45:56.774+0100 [DEBUG] plugin.terraform-provider-azurerm_v1.19.0_x4: net/rpc.(*service).call(0xc000046180, 0xc0003041e0, 0xc00070c050, 0xc00070c060, 0xc000190580, 0xc000174100, 0x1dfba60, 0xc0004684a0, 0x16, 0x1dfbaa0, ...)
2018-12-06T18:45:56.774+0100 [DEBUG] plugin.terraform-provider-azurerm_v1.19.0_x4:      /opt/goenv/versions/1.11.1/src/net/rpc/server.go:384 +0x14e
2018-12-06T18:45:56.774+0100 [DEBUG] plugin.terraform-provider-azurerm_v1.19.0_x4: created by net/rpc.(*Server).ServeCodec
2018-12-06T18:45:56.774+0100 [DEBUG] plugin.terraform-provider-azurerm_v1.19.0_x4:      /opt/goenv/versions/1.11.1/src/net/rpc/server.go:481 +0x47e
```