### PR TITLE
refactor: removing unused code leftover from the azure cli parsing auth

### DIFF
--- a/authentication/azure_cli_access_token.go
+++ b/authentication/azure_cli_access_token.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"strings"
-	"time"
 
 	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/Azure/go-autorest/autorest/azure/cli"
@@ -15,21 +14,11 @@ type azureCliAccessToken struct {
 	AccessToken  *adal.Token
 }
 
-func findValidAccessTokenForTenant(tokens []cli.Token, tenantId string, allowExpired bool) (*azureCliAccessToken, error) {
+func findValidAccessTokenForTenant(tokens []cli.Token, tenantId string) (*azureCliAccessToken, error) {
 	for _, accessToken := range tokens {
 		token, err := accessToken.ToADALToken()
 		if err != nil {
 			return nil, fmt.Errorf("[DEBUG] Error converting access token to token: %+v", err)
-		}
-
-		expirationDate, err := cli.ParseExpirationDate(accessToken.ExpiresOn)
-		if err != nil {
-			return nil, fmt.Errorf("Error parsing expiration date: %q", accessToken.ExpiresOn)
-		}
-
-		if expirationDate.UTC().Before(time.Now().UTC()) && !allowExpired {
-			log.Printf("[DEBUG] Token %q has expired", token.AccessToken)
-			continue
 		}
 
 		if !strings.Contains(accessToken.Resource, "management") {

--- a/authentication/azure_cli_access_token_test.go
+++ b/authentication/azure_cli_access_token_test.go
@@ -7,28 +7,6 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure/cli"
 )
 
-func TestAzureFindValidAccessTokenForTenant_InvalidDate(t *testing.T) {
-	tenantId := "c056adac-c6a6-4ddf-ab20-0f26d47f7eea"
-	expectedToken := cli.Token{
-		ExpiresOn:    "invalid date",
-		AccessToken:  "7cabcf30-8dca-43f9-91e6-fd56dfb8632f",
-		TokenType:    "9b10b986-7a61-4542-8d5a-9fcd96112585",
-		RefreshToken: "4ec3874d-ee2e-4980-ba47-b5bac11ddb94",
-		Resource:     "https://management.core.windows.net/",
-		Authority:    tenantId,
-	}
-	tokens := []cli.Token{expectedToken}
-	token, err := findValidAccessTokenForTenant(tokens, tenantId, false)
-
-	if err == nil {
-		t.Fatalf("Expected an error to be returned but got nil")
-	}
-
-	if token != nil {
-		t.Fatalf("Expected Token to be nil but got: %+v", token)
-	}
-}
-
 func TestAzureFindValidAccessTokenForTenant_Expired(t *testing.T) {
 	expirationDate := time.Now().Add(time.Minute * -1)
 	tenantId := "c056adac-c6a6-4ddf-ab20-0f26d47f7eea"
@@ -41,30 +19,7 @@ func TestAzureFindValidAccessTokenForTenant_Expired(t *testing.T) {
 		Authority:    tenantId,
 	}
 	tokens := []cli.Token{expectedToken}
-	token, err := findValidAccessTokenForTenant(tokens, tenantId, false)
-
-	if err == nil {
-		t.Fatalf("Expected an error to be returned but got nil")
-	}
-
-	if token != nil {
-		t.Fatalf("Expected Token to be nil but got: %+v", token)
-	}
-}
-
-func TestAzureFindValidAccessTokenForTenant_ExpiredAllowingExpiredToken(t *testing.T) {
-	expirationDate := time.Now().Add(time.Minute * -1)
-	tenantId := "c056adac-c6a6-4ddf-ab20-0f26d47f7eea"
-	expectedToken := cli.Token{
-		ExpiresOn:    expirationDate.Format("2006-01-02 15:04:05.999999"),
-		AccessToken:  "7cabcf30-8dca-43f9-91e6-fd56dfb8632f",
-		TokenType:    "9b10b986-7a61-4542-8d5a-9fcd96112585",
-		RefreshToken: "4ec3874d-ee2e-4980-ba47-b5bac11ddb94",
-		Resource:     "https://management.core.windows.net/",
-		Authority:    tenantId,
-	}
-	tokens := []cli.Token{expectedToken}
-	token, err := findValidAccessTokenForTenant(tokens, tenantId, true)
+	token, err := findValidAccessTokenForTenant(tokens, tenantId)
 
 	if err != nil {
 		t.Fatalf("Expected no error to be returned but got: %+v", err)
@@ -90,7 +45,7 @@ func TestAzureFindValidAccessTokenForTenant_ExpiringIn(t *testing.T) {
 			Authority:    tenantId,
 		}
 		tokens := []cli.Token{expectedToken}
-		token, err := findValidAccessTokenForTenant(tokens, tenantId, false)
+		token, err := findValidAccessTokenForTenant(tokens, tenantId)
 
 		if err != nil {
 			t.Fatalf("Expected no error to be returned for minute %d but got %+v", minute, err)
@@ -121,7 +76,7 @@ func TestAzureFindValidAccessTokenForTenant_InvalidManagementDomain(t *testing.T
 		Authority:   tenantId,
 	}
 	tokens := []cli.Token{expectedToken}
-	token, err := findValidAccessTokenForTenant(tokens, tenantId, false)
+	token, err := findValidAccessTokenForTenant(tokens, tenantId)
 
 	if err == nil {
 		t.Fatalf("Expected an error but didn't get one")
@@ -142,7 +97,7 @@ func TestAzureFindValidAccessTokenForTenant_DifferentTenant(t *testing.T) {
 		Authority:   "9b5095de-5496-4b5e-9bc6-ef2c017b9d35",
 	}
 	tokens := []cli.Token{expectedToken}
-	token, err := findValidAccessTokenForTenant(tokens, "c056adac-c6a6-4ddf-ab20-0f26d47f7eea", false)
+	token, err := findValidAccessTokenForTenant(tokens, "c056adac-c6a6-4ddf-ab20-0f26d47f7eea")
 
 	if err == nil {
 		t.Fatalf("Expected an error but didn't get one")
@@ -165,7 +120,7 @@ func TestAzureFindValidAccessTokenForTenant_Valid(t *testing.T) {
 		Authority:    tenantId,
 	}
 	tokens := []cli.Token{expectedToken}
-	token, err := findValidAccessTokenForTenant(tokens, tenantId, false)
+	token, err := findValidAccessTokenForTenant(tokens, tenantId)
 
 	if err != nil {
 		t.Fatalf("Expected no error to be returned but got %+v", err)
@@ -186,7 +141,7 @@ func TestAzureFindValidAccessTokenForTenant_Valid(t *testing.T) {
 
 func TestAzureFindValidAccessTokenForTenant_NoTokens(t *testing.T) {
 	tokens := make([]cli.Token, 0)
-	token, err := findValidAccessTokenForTenant(tokens, "abc123", false)
+	token, err := findValidAccessTokenForTenant(tokens, "abc123")
 
 	if err == nil {
 		t.Fatalf("Expected an error but didn't get one")

--- a/authentication/azure_cli_profile_population.go
+++ b/authentication/azure_cli_profile_population.go
@@ -39,7 +39,7 @@ func (a *azureCLIProfile) populateClientId() error {
 		return fmt.Errorf("No Authorization Tokens were found - please ensure the Azure CLI is installed and then log-in with `az login`.")
 	}
 
-	validToken, err := findValidAccessTokenForTenant(tokens, a.tenantId, true)
+	validToken, err := findValidAccessTokenForTenant(tokens, a.tenantId)
 	if err != nil {
 		return fmt.Errorf("No Authorization Tokens were found - please re-authenticate using `az login`.")
 	}


### PR DESCRIPTION
since we no longer require valid tokens (since we always request one) - we can also clean up this code path too