### PR TITLE
Wrapping the azure cli error for a more helpful error

### DIFF
--- a/authentication/auth_method_azure_cli_token.go
+++ b/authentication/auth_method_azure_cli_token.go
@@ -40,7 +40,7 @@ func (a azureCliTokenAuth) build(b Builder) (authMethod, error) {
 
 	err = auth.profile.populateFields()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Error retrieving the Profile from the Azure CLI: %s Please re-authenticate using `az login`.", err)
 	}
 
 	err = auth.profile.populateClientId()


### PR DESCRIPTION
Currently when the user is trying to use Azure CLI authentication, but isn't logged in they get this error:

```
* provider.azurerm: Error building AzureRM Client: No Subscription was Marked as Default in the Azure Profile.
```

This PR wraps this error telling the user to login:

```
* provider.azurerm: Error building AzureRM Client: Error retrieving the Profile from the Azure CLI: No Subscription was Marked as Default in the Azure Profile. Please re-authenticate using `az login`.
```