### PR TITLE
passing the sender to the request method

### DIFF
--- a/authentication/auth_method.go
+++ b/authentication/auth_method.go
@@ -10,7 +10,7 @@ type authMethod interface {
 
 	isApplicable(b Builder) bool
 
-	getAuthorizationToken(oauthConfig *adal.OAuthConfig, endpoint string) (*autorest.BearerAuthorizer, error)
+	getAuthorizationToken(sender autorest.Sender, oauthConfig *adal.OAuthConfig, endpoint string) (*autorest.BearerAuthorizer, error)
 
 	name() string
 

--- a/authentication/auth_method_azure_cli_token.go
+++ b/authentication/auth_method_azure_cli_token.go
@@ -55,7 +55,7 @@ func (a azureCliTokenAuth) isApplicable(b Builder) bool {
 	return b.SupportsAzureCliToken
 }
 
-func (a azureCliTokenAuth) getAuthorizationToken(oauthConfig *adal.OAuthConfig, endpoint string) (*autorest.BearerAuthorizer, error) {
+func (a azureCliTokenAuth) getAuthorizationToken(sender autorest.Sender, oauthConfig *adal.OAuthConfig, endpoint string) (*autorest.BearerAuthorizer, error) {
 	// the Azure CLI appears to cache these, so to maintain compatibility with the interface this method is intentionally not on the pointer
 	token, err := obtainAuthorizationToken(endpoint, a.profile.subscriptionId)
 	if err != nil {

--- a/authentication/auth_method_client_cert.go
+++ b/authentication/auth_method_client_cert.go
@@ -41,7 +41,7 @@ func (a servicePrincipalClientCertificateAuth) name() string {
 	return "Service Principal / Client Certificate"
 }
 
-func (a servicePrincipalClientCertificateAuth) getAuthorizationToken(oauthConfig *adal.OAuthConfig, endpoint string) (*autorest.BearerAuthorizer, error) {
+func (a servicePrincipalClientCertificateAuth) getAuthorizationToken(sender autorest.Sender, oauthConfig *adal.OAuthConfig, endpoint string) (*autorest.BearerAuthorizer, error) {
 	certificateData, err := ioutil.ReadFile(a.clientCertPath)
 	if err != nil {
 		return nil, fmt.Errorf("Error reading Client Certificate %q: %v", a.clientCertPath, err)
@@ -57,6 +57,8 @@ func (a servicePrincipalClientCertificateAuth) getAuthorizationToken(oauthConfig
 	if err != nil {
 		return nil, err
 	}
+
+	spt.SetSender(sender)
 
 	err = spt.Refresh()
 	if err != nil {

--- a/authentication/auth_method_client_secret.go
+++ b/authentication/auth_method_client_secret.go
@@ -33,11 +33,12 @@ func (a servicePrincipalClientSecretAuth) name() string {
 	return "Service Principal / Client Secret"
 }
 
-func (a servicePrincipalClientSecretAuth) getAuthorizationToken(oauthConfig *adal.OAuthConfig, endpoint string) (*autorest.BearerAuthorizer, error) {
+func (a servicePrincipalClientSecretAuth) getAuthorizationToken(sender autorest.Sender, oauthConfig *adal.OAuthConfig, endpoint string) (*autorest.BearerAuthorizer, error) {
 	spt, err := adal.NewServicePrincipalToken(*oauthConfig, a.clientId, a.clientSecret, endpoint)
 	if err != nil {
 		return nil, err
 	}
+	spt.SetSender(sender)
 
 	auth := autorest.NewBearerAuthorizer(spt)
 	return auth, nil

--- a/authentication/auth_method_msi.go
+++ b/authentication/auth_method_msi.go
@@ -39,11 +39,14 @@ func (a managedServiceIdentityAuth) name() string {
 	return "Managed Service Identity"
 }
 
-func (a managedServiceIdentityAuth) getAuthorizationToken(oauthConfig *adal.OAuthConfig, endpoint string) (*autorest.BearerAuthorizer, error) {
+func (a managedServiceIdentityAuth) getAuthorizationToken(sender autorest.Sender, oauthConfig *adal.OAuthConfig, endpoint string) (*autorest.BearerAuthorizer, error) {
 	spt, err := adal.NewServicePrincipalTokenFromMSI(a.endpoint, endpoint)
 	if err != nil {
 		return nil, err
 	}
+
+	spt.SetSender(sender)
+
 	auth := autorest.NewBearerAuthorizer(spt)
 	return auth, nil
 }

--- a/authentication/config.go
+++ b/authentication/config.go
@@ -22,8 +22,8 @@ type Config struct {
 }
 
 // GetAuthorizationToken returns an authorization token for the authentication method defined in the Config
-func (c Config) GetAuthorizationToken(oauthConfig *adal.OAuthConfig, endpoint string) (*autorest.BearerAuthorizer, error) {
-	return c.authMethod.getAuthorizationToken(oauthConfig, endpoint)
+func (c Config) GetAuthorizationToken(sender autorest.Sender, oauthConfig *adal.OAuthConfig, endpoint string) (*autorest.BearerAuthorizer, error) {
+	return c.authMethod.getAuthorizationToken(sender, oauthConfig, endpoint)
 }
 
 func (c Config) validate() (*Config, error) {


### PR DESCRIPTION
This allows the same sender to be sent for both the Auth requests and Client requests; which should ensure the proxy configuration is the same