### PR TITLE
Fix the code logic to generate the required provider list.

### DIFF
--- a/resourceproviders/registration.go
+++ b/resourceproviders/registration.go
@@ -14,7 +14,7 @@ import (
 func DetermineResourceProvidersRequiringRegistration(availableResourceProviders []resources.Provider, requiredResourceProviders map[string]struct{}) map[string]struct{} {
 	providers := make(map[string]struct{})
 
-	// filter out any providers already registered
+	// filter out any providers already registered and not in the required list.
 	for _, p := range availableResourceProviders {
 		// Skip it if it's not in the required list.
 		if _, ok := requiredResourceProviders[*p.Namespace]; !ok {

--- a/resourceproviders/registration.go
+++ b/resourceproviders/registration.go
@@ -12,17 +12,19 @@ import (
 
 // DetermineResourceProvidersRequiringRegistration determines which Resource Providers require registration to be able to be used
 func DetermineResourceProvidersRequiringRegistration(availableResourceProviders []resources.Provider, requiredResourceProviders map[string]struct{}) map[string]struct{} {
-	providers := requiredResourceProviders
+	providers := make(map[string]struct{})
 
 	// filter out any providers already registered
 	for _, p := range availableResourceProviders {
-		if _, ok := providers[*p.Namespace]; !ok {
+		// Skip it if it's not in the required list.
+		if _, ok := requiredResourceProviders[*p.Namespace]; !ok {
 			continue
 		}
 
-		if strings.ToLower(*p.RegistrationState) == "registered" {
-			log.Printf("[DEBUG] Skipping provider registration for namespace %s\n", *p.Namespace)
-			delete(providers, *p.Namespace)
+		// If it's in the required list but not registered.
+		if strings.ToLower(*p.RegistrationState) != "registered" {
+			log.Printf("[DEBUG] Adding provider registration for namespace %s\n", *p.Namespace)
+			providers[*p.Namespace] = requiredResourceProviders[*p.Namespace]
 		}
 	}
 


### PR DESCRIPTION
This PR is created to address the regression issue after upgrading to `v0.4.0` recently:
https://github.com/terraform-providers/terraform-provider-azurerm/issues/3312

Before making this change, if you ran any acceptance test like `TestAccAzureRMResourceGroup_basic`, you will see below error:
```
Error: Error ensuring Resource Providers are registered: Cannot register provider Microsoft.Cdn 
with Azure Resource Manager: resources.ProvidersClient#Register: Failure responding to request:
StatusCode=404 -- Original Error: autorest/azure: Service returned an error. Status=404 
Code="InvalidResourceNamespace" Message="The resource namespace 'Microsoft.Cdn' is invalid.".
```

With this change, the test can pass.