### PR TITLE
Add function to compute SAS token for blob container

### DIFF
--- a/storage/sas_token_test.go
+++ b/storage/sas_token_test.go
@@ -1,6 +1,10 @@
 package storage
 
-import "testing"
+import (
+	"net/url"
+	"strings"
+	"testing"
+)
 
 func TestParseStorageAccountConnectionString(t *testing.T) {
 	testCases := []struct {
@@ -33,7 +37,7 @@ func TestParseStorageAccountConnectionString(t *testing.T) {
 			return
 		}
 
-		if ! test.expectedError && err != nil {
+		if !test.expectedError && err != nil {
 			t.Fatalf("Failed to parse resource type string: %s, %q", test.input, result)
 		}
 
@@ -49,7 +53,7 @@ func TestParseStorageAccountConnectionString(t *testing.T) {
 // This connection string was for a real storage account which has been deleted
 // so its safe to include here for reference to understand the format.
 // DefaultEndpointsProtocol=https;AccountName=azurermtestsa0;AccountKey=T0ZQouXBDpWud/PlTRHIJH2+VUK8D+fnedEynb9Mx638IYnsMUe4mv1fFjC7t0NayTfFAQJzPZuV1WHFKOzGdg==;EndpointSuffix=core.windows.net
-func TestComputeSASToken(t *testing.T) {
+func TestComputeAccountSASToken(t *testing.T) {
 	testCases := []struct {
 		accountName    string
 		accountKey     string
@@ -111,4 +115,129 @@ func TestComputeSASToken(t *testing.T) {
 			t.Fatalf("Test failed: Expected Azure SAS %s but was %s", test.knownSasToken, computedToken)
 		}
 	}
+}
+
+func TestComputeContainerSASToken(t *testing.T) {
+	testCases := []struct {
+		signedPermissions  string
+		signedStart        string
+		signedExpiry       string
+		accountName        string
+		accountKey         string
+		containerName      string
+		signedIdentifier   string
+		signedIp           string
+		signedProtocol     string
+		signedSnapshotTime string
+		cacheControl       string
+		contentDisposition string
+		contentEncoding    string
+		contentLanguage    string
+		contentType        string
+		knownSasToken      string
+	}{
+		{
+			"rwl",
+			"2019-03-27",
+			"2019-09-21T09:21Z",
+			"azurermblobcontainertest",
+			"y3PNtHAAyjMSRHZ26n/ISyXt1IpXLIqiwAUQ602Un8AJX2JL3MMEbxK7ue45nr9BB0BibegTkQ5rdrgMR5CZkA==",
+			"test-container",
+			"",
+			"",
+			"https",
+			"",
+			"",
+			"",
+			"",
+			"",
+			"",
+			"?st=2019-03-27&se=2019-09-21T09%3A21Z&sp=rwl&spr=https&sv=2018-11-09&sr=c&sig=DnHeyj11jpfGEmdskSIuASIZorLghcjLbKN90n%2B6UO4%3D",
+		},
+		{
+			"rwl",
+			"2019-03-27",
+			"2019-09-21T09:21Z",
+			"azurermblobcontainertest",
+			"y3PNtHAAyjMSRHZ26n/ISyXt1IpXLIqiwAUQ602Un8AJX2JL3MMEbxK7ue45nr9BB0BibegTkQ5rdrgMR5CZkA==",
+			"test-container",
+			"",
+			"93.23.223.54",
+			"https",
+			"",
+			"no-cache",
+			"attachment",
+			"gzip",
+			"en-US",
+			"text/html; charset=utf-8",
+			"?st=2019-03-27&se=2019-09-21T09%3A21Z&sp=rwl&sip=93.23.223.54&spr=https&sv=2018-11-09&sr=c&rscc=no-cache&rscd=attachment&rsce=gzip&rscl=en-US&rsct=text/html%3B%20charset%3Dutf-8&sig=M2TaUVEGlRVJjNt/c7Eqt2zH6%2BA8dpiLmTXR0ZevEX8%3D",
+		},
+	}
+
+	for _, test := range testCases {
+		computedToken, err := ComputeContainerSASToken(test.signedPermissions,
+			test.signedStart,
+			test.signedExpiry,
+			test.accountName,
+			test.accountKey,
+			test.containerName,
+			test.signedIdentifier,
+			test.signedIp,
+			test.signedProtocol,
+			test.signedSnapshotTime,
+			test.cacheControl,
+			test.contentDisposition,
+			test.contentEncoding,
+			test.contentLanguage,
+			test.contentType)
+
+		if err != nil {
+			t.Fatalf("Test Failed: Error computing blob container Sas: %q", err)
+		}
+
+		if !compareSASTokens(computedToken, test.knownSasToken) {
+			t.Fatalf("Test failed: Expected Azure SAS %s but was %s", test.knownSasToken, computedToken)
+		}
+	}
+}
+
+func compareSASTokens(token1 string, token2 string) bool {
+	queryParams1 := parseSASToken(token1)
+	queryParams2 := parseSASToken(token2)
+
+	if len(queryParams1) != len(queryParams2) {
+		return false
+	}
+
+	for k, v1 := range queryParams1 {
+		if v2, ok := queryParams2[k]; ok {
+			// values need to be unescaped because apperently azure cli escape does not seem to work correctly (e.g. for contentType value)
+			// example: text/html; charset=utf-8
+			// -> escaped in go: text%2Fhtml%3B+charset%3Dutf-8
+			// -> escaped in python / azure cli: text/html%3B%20charset%3Dutf-8
+			unescapedValue1, _ := url.QueryUnescape(v1)
+			unescapedValue2, _ := url.QueryUnescape(v2)
+			if unescapedValue1 != unescapedValue2 {
+				return false
+			}
+		} else {
+			return false
+		}
+	}
+
+	return true
+}
+
+func parseSASToken(token string) map[string]string {
+	queryParts := strings.Split(token[1:], "&")
+
+	kvp := make(map[string]string)
+	for _, queryPart := range queryParts {
+		kv := strings.SplitN(queryPart, "=", 2)
+		key := kv[0]
+		value := kv[1]
+		kvp[key] = value
+	}
+
+	return kvp
 }


### PR DESCRIPTION
Hey,
i need this functionality in order to create SAS tokens for blob containers in at least two use cases:
- `azurerm_analysis_services_server`: backup blob container + sas
- `azurerm_data_factory_integration_runtime_managed`: custom setup script container + sas

I'm going to implement a data provider for this token. It is similar to the storage account SAS token but does not exist yet.