### PR TITLE
Auth: exposing the Primary and Multi Tenant Authorizers

### DIFF
--- a/authentication/auth_method.go
+++ b/authentication/auth_method.go
@@ -9,7 +9,7 @@ type authMethod interface {
 
 	isApplicable(b Builder) bool
 
-	getAuthorizationToken(sender autorest.Sender, oauthConfig *MultiOAuth, endpoint string) (autorest.Authorizer, error)
+	getAuthorizationToken(sender autorest.Sender, oauthConfig *AuthConfig, endpoint string) (autorest.Authorizer, error)
 
 	name() string
 

--- a/authentication/auth_method.go
+++ b/authentication/auth_method.go
@@ -9,7 +9,7 @@ type authMethod interface {
 
 	isApplicable(b Builder) bool
 
-	getAuthorizationToken(sender autorest.Sender, oauthConfig *AuthConfig, endpoint string) (autorest.Authorizer, error)
+	getAuthorizationToken(sender autorest.Sender, oauthConfig *OAuthConfig, endpoint string) (autorest.Authorizer, error)
 
 	name() string
 

--- a/authentication/auth_method_azure_cli_token.go
+++ b/authentication/auth_method_azure_cli_token.go
@@ -68,7 +68,7 @@ func (a azureCliTokenAuth) isApplicable(b Builder) bool {
 	return b.SupportsAzureCliToken
 }
 
-func (a azureCliTokenAuth) getAuthorizationToken(sender autorest.Sender, oauth *MultiOAuth, endpoint string) (autorest.Authorizer, error) {
+func (a azureCliTokenAuth) getAuthorizationToken(sender autorest.Sender, oauth *AuthConfig, endpoint string) (autorest.Authorizer, error) {
 	if oauth.OAuth == nil {
 		return nil, fmt.Errorf("Error getting Authorization Token for cli auth: an OAuth token wasn't configured correctly; please file a bug with more details")
 	}

--- a/authentication/auth_method_azure_cli_token.go
+++ b/authentication/auth_method_azure_cli_token.go
@@ -68,7 +68,7 @@ func (a azureCliTokenAuth) isApplicable(b Builder) bool {
 	return b.SupportsAzureCliToken
 }
 
-func (a azureCliTokenAuth) getAuthorizationToken(sender autorest.Sender, oauth *AuthConfig, endpoint string) (autorest.Authorizer, error) {
+func (a azureCliTokenAuth) getAuthorizationToken(sender autorest.Sender, oauth *OAuthConfig, endpoint string) (autorest.Authorizer, error) {
 	if oauth.OAuth == nil {
 		return nil, fmt.Errorf("Error getting Authorization Token for cli auth: an OAuth token wasn't configured correctly; please file a bug with more details")
 	}

--- a/authentication/auth_method_client_cert.go
+++ b/authentication/auth_method_client_cert.go
@@ -41,7 +41,7 @@ func (a servicePrincipalClientCertificateAuth) name() string {
 	return "Service Principal / Client Certificate"
 }
 
-func (a servicePrincipalClientCertificateAuth) getAuthorizationToken(sender autorest.Sender, oauth *AuthConfig, endpoint string) (autorest.Authorizer, error) {
+func (a servicePrincipalClientCertificateAuth) getAuthorizationToken(sender autorest.Sender, oauth *OAuthConfig, endpoint string) (autorest.Authorizer, error) {
 	if oauth.OAuth == nil {
 		return nil, fmt.Errorf("Error getting Authorization Token for client cert: an OAuth token wasn't configured correctly; please file a bug with more details")
 	}

--- a/authentication/auth_method_client_cert.go
+++ b/authentication/auth_method_client_cert.go
@@ -41,7 +41,7 @@ func (a servicePrincipalClientCertificateAuth) name() string {
 	return "Service Principal / Client Certificate"
 }
 
-func (a servicePrincipalClientCertificateAuth) getAuthorizationToken(sender autorest.Sender, oauth *MultiOAuth, endpoint string) (autorest.Authorizer, error) {
+func (a servicePrincipalClientCertificateAuth) getAuthorizationToken(sender autorest.Sender, oauth *AuthConfig, endpoint string) (autorest.Authorizer, error) {
 	if oauth.OAuth == nil {
 		return nil, fmt.Errorf("Error getting Authorization Token for client cert: an OAuth token wasn't configured correctly; please file a bug with more details")
 	}

--- a/authentication/auth_method_client_secret.go
+++ b/authentication/auth_method_client_secret.go
@@ -33,7 +33,7 @@ func (a servicePrincipalClientSecretAuth) name() string {
 	return "Service Principal / Client Secret"
 }
 
-func (a servicePrincipalClientSecretAuth) getAuthorizationToken(sender autorest.Sender, oauth *AuthConfig, endpoint string) (autorest.Authorizer, error) {
+func (a servicePrincipalClientSecretAuth) getAuthorizationToken(sender autorest.Sender, oauth *OAuthConfig, endpoint string) (autorest.Authorizer, error) {
 	if oauth.OAuth == nil {
 		return nil, fmt.Errorf("Error getting Authorization Token for client secret auth: an OAuth token wasn't configured correctly; please file a bug with more details")
 	}

--- a/authentication/auth_method_client_secret.go
+++ b/authentication/auth_method_client_secret.go
@@ -33,7 +33,7 @@ func (a servicePrincipalClientSecretAuth) name() string {
 	return "Service Principal / Client Secret"
 }
 
-func (a servicePrincipalClientSecretAuth) getAuthorizationToken(sender autorest.Sender, oauth *MultiOAuth, endpoint string) (autorest.Authorizer, error) {
+func (a servicePrincipalClientSecretAuth) getAuthorizationToken(sender autorest.Sender, oauth *AuthConfig, endpoint string) (autorest.Authorizer, error) {
 	if oauth.OAuth == nil {
 		return nil, fmt.Errorf("Error getting Authorization Token for client secret auth: an OAuth token wasn't configured correctly; please file a bug with more details")
 	}

--- a/authentication/auth_method_client_secret_multi_tenant.go
+++ b/authentication/auth_method_client_secret_multi_tenant.go
@@ -35,7 +35,7 @@ func (a servicePrincipalClientSecretMultiTenantAuth) name() string {
 	return "Multi Tenant Service Principal / Client Secret"
 }
 
-func (a servicePrincipalClientSecretMultiTenantAuth) getAuthorizationToken(sender autorest.Sender, oauth *MultiOAuth, endpoint string) (autorest.Authorizer, error) {
+func (a servicePrincipalClientSecretMultiTenantAuth) getAuthorizationToken(sender autorest.Sender, oauth *AuthConfig, endpoint string) (autorest.Authorizer, error) {
 	if oauth.MultiTenantOauth == nil {
 		return nil, fmt.Errorf("Error getting Authorization Token for client cert: an MultiTenantOauth token wasn't configured correctly; please file a bug with more details")
 	}

--- a/authentication/auth_method_client_secret_multi_tenant.go
+++ b/authentication/auth_method_client_secret_multi_tenant.go
@@ -35,7 +35,7 @@ func (a servicePrincipalClientSecretMultiTenantAuth) name() string {
 	return "Multi Tenant Service Principal / Client Secret"
 }
 
-func (a servicePrincipalClientSecretMultiTenantAuth) getAuthorizationToken(sender autorest.Sender, oauth *AuthConfig, endpoint string) (autorest.Authorizer, error) {
+func (a servicePrincipalClientSecretMultiTenantAuth) getAuthorizationToken(sender autorest.Sender, oauth *OAuthConfig, endpoint string) (autorest.Authorizer, error) {
 	if oauth.MultiTenantOauth == nil {
 		return nil, fmt.Errorf("Error getting Authorization Token for client cert: an MultiTenantOauth token wasn't configured correctly; please file a bug with more details")
 	}

--- a/authentication/auth_method_msi.go
+++ b/authentication/auth_method_msi.go
@@ -39,7 +39,7 @@ func (a managedServiceIdentityAuth) name() string {
 	return "Managed Service Identity"
 }
 
-func (a managedServiceIdentityAuth) getAuthorizationToken(sender autorest.Sender, oauth *MultiOAuth, endpoint string) (autorest.Authorizer, error) {
+func (a managedServiceIdentityAuth) getAuthorizationToken(sender autorest.Sender, oauth *AuthConfig, endpoint string) (autorest.Authorizer, error) {
 	if oauth.OAuth == nil {
 		return nil, fmt.Errorf("Error getting Authorization Token for MSI auth: an OAuth token wasn't configured correctly; please file a bug with more details")
 	}

--- a/authentication/auth_method_msi.go
+++ b/authentication/auth_method_msi.go
@@ -39,7 +39,7 @@ func (a managedServiceIdentityAuth) name() string {
 	return "Managed Service Identity"
 }
 
-func (a managedServiceIdentityAuth) getAuthorizationToken(sender autorest.Sender, oauth *AuthConfig, endpoint string) (autorest.Authorizer, error) {
+func (a managedServiceIdentityAuth) getAuthorizationToken(sender autorest.Sender, oauth *OAuthConfig, endpoint string) (autorest.Authorizer, error) {
 	if oauth.OAuth == nil {
 		return nil, fmt.Errorf("Error getting Authorization Token for MSI auth: an OAuth token wasn't configured correctly; please file a bug with more details")
 	}

--- a/authentication/config.go
+++ b/authentication/config.go
@@ -25,7 +25,7 @@ type Config struct {
 	authMethod authMethod
 }
 
-type AuthConfig struct {
+type OAuthConfig struct {
 	OAuth            *adal.OAuthConfig
 	MultiTenantOauth *adal.MultiTenantOAuthConfig
 }
@@ -63,8 +63,8 @@ func (c Config) GetMultiTenantOAuthConfig(activeDirectoryEndpoint string) (*adal
 }
 
 // BuildOAuthConfig builds the authorization configuration for the specified Active Directory Endpoint
-func (c Config) BuildOAuthConfig(activeDirectoryEndpoint string) (*AuthConfig, error) {
-	multiAuth := AuthConfig{}
+func (c Config) BuildOAuthConfig(activeDirectoryEndpoint string) (*OAuthConfig, error) {
+	multiAuth := OAuthConfig{}
 	var err error
 
 	multiAuth.OAuth, err = c.GetOAuthConfig(activeDirectoryEndpoint)
@@ -84,10 +84,10 @@ func (c Config) BuildOAuthConfig(activeDirectoryEndpoint string) (*AuthConfig, e
 
 // BearerAuthorizerCallback returns a BearerAuthorizer valid only for the Primary Tenant
 // this signs a request using the AccessToken returned from the primary Resource Manager authorizer
-func (c Config) BearerAuthorizerCallback(sender autorest.Sender, oauthConfig *AuthConfig) *autorest.BearerAuthorizerCallback {
+func (c Config) BearerAuthorizerCallback(sender autorest.Sender, oauthConfig *OAuthConfig) *autorest.BearerAuthorizerCallback {
 	return autorest.NewBearerAuthorizerCallback(sender, func(tenantID, resource string) (*autorest.BearerAuthorizer, error) {
 		// a BearerAuthorizer is only valid for the primary tenant
-		newAuthConfig := &AuthConfig{
+		newAuthConfig := &OAuthConfig{
 			OAuth: oauthConfig.OAuth,
 		}
 
@@ -106,6 +106,6 @@ func (c Config) BearerAuthorizerCallback(sender autorest.Sender, oauthConfig *Au
 }
 
 // GetAuthorizationToken returns an authorization token for the authentication method defined in the Config
-func (c Config) GetAuthorizationToken(sender autorest.Sender, oauth *AuthConfig, endpoint string) (autorest.Authorizer, error) {
+func (c Config) GetAuthorizationToken(sender autorest.Sender, oauth *OAuthConfig, endpoint string) (autorest.Authorizer, error) {
 	return c.authMethod.getAuthorizationToken(sender, oauth, endpoint)
 }

--- a/authentication/config.go
+++ b/authentication/config.go
@@ -25,7 +25,7 @@ type Config struct {
 	authMethod authMethod
 }
 
-type MultiOAuth struct {
+type AuthConfig struct {
 	OAuth            *adal.OAuthConfig
 	MultiTenantOauth *adal.MultiTenantOAuthConfig
 }
@@ -62,17 +62,50 @@ func (c Config) GetMultiTenantOAuthConfig(activeDirectoryEndpoint string) (*adal
 	return &oauth, nil
 }
 
-func (c Config) GetMultiOAuthConfig(activeDirectoryEndpoint string) (*MultiOAuth, error) {
-	if len(c.AuxiliaryTenantIDs) == 0 {
-		oauth, err := c.GetOAuthConfig(activeDirectoryEndpoint)
-		return &MultiOAuth{OAuth: oauth}, err
+// BuildOAuthConfig builds the authorization configuration for the specified Active Directory Endpoint
+func (c Config) BuildOAuthConfig(activeDirectoryEndpoint string) (*AuthConfig, error) {
+	multiAuth := AuthConfig{}
+	var err error
+
+	multiAuth.OAuth, err = c.GetOAuthConfig(activeDirectoryEndpoint)
+	if err != nil {
+		return nil, err
 	}
 
-	oauth, err := c.GetMultiTenantOAuthConfig(activeDirectoryEndpoint)
-	return &MultiOAuth{MultiTenantOauth: oauth}, err
+	if len(c.AuxiliaryTenantIDs) > 0 {
+		multiAuth.MultiTenantOauth, err = c.GetMultiTenantOAuthConfig(activeDirectoryEndpoint)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &multiAuth, nil
+}
+
+// BearerAuthorizerCallback returns a BearerAuthorizer valid only for the Primary Tenant
+// this signs a request using the AccessToken returned from the primary Resource Manager authorizer
+func (c Config) BearerAuthorizerCallback(sender autorest.Sender, oauthConfig *AuthConfig) *autorest.BearerAuthorizerCallback {
+	return autorest.NewBearerAuthorizerCallback(sender, func(tenantID, resource string) (*autorest.BearerAuthorizer, error) {
+		// a BearerAuthorizer is only valid for the primary tenant
+		newAuthConfig := &AuthConfig{
+			OAuth: oauthConfig.OAuth,
+		}
+
+		storageSpt, err := c.GetAuthorizationToken(sender, newAuthConfig, resource)
+		if err != nil {
+			return nil, err
+		}
+
+		cast, ok := storageSpt.(*autorest.BearerAuthorizer)
+		if !ok {
+			return nil, fmt.Errorf("Error converting %+v to a BearerAuthorizer", storageSpt)
+		}
+
+		return cast, nil
+	})
 }
 
 // GetAuthorizationToken returns an authorization token for the authentication method defined in the Config
-func (c Config) GetAuthorizationToken(sender autorest.Sender, oauth *MultiOAuth, endpoint string) (autorest.Authorizer, error) {
+func (c Config) GetAuthorizationToken(sender autorest.Sender, oauth *AuthConfig, endpoint string) (autorest.Authorizer, error) {
 	return c.authMethod.getAuthorizationToken(sender, oauth, endpoint)
 }


### PR DESCRIPTION
This PR does a couple of things necessary to be able to use the Key Vault and Storage Authorizers within the Azure Providers:

1. Exposes both the Primary and Multi Tenant authorizers to be able to return an Authorizer for the Primary Tenant
2. .. via the new method `BearerAuthorizerCallback` which can be used to obtain a BearerAuthorizerCallback for the Primary Tenant - which in turn can be used for the Key Vault and Storage Authorizers which require using the Primary Tenant

There's a couple of renames in here too:

1. Renaming the struct `MultiOAuth` struct to `AuthConfig`
2. Renaming the func `GetMultiOAuthConfig` to `BuildOAuthConfig`, since it's building the OAuth Configuration

Tests pass:

```
$ make test
go mod download
warning: pattern "all" matched no module dependencies
go vet ./...
go test -race ./...
ok  	github.com/hashicorp/go-azure-helpers/authentication	1.024s
?   	github.com/hashicorp/go-azure-helpers/resourceproviders	[no test files]
ok  	github.com/hashicorp/go-azure-helpers/response	1.023s
?   	github.com/hashicorp/go-azure-helpers/sender	[no test files]
ok  	github.com/hashicorp/go-azure-helpers/storage	1.016s
```