### PR TITLE
Read a refresh token from accessTokens.json

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,5 +9,6 @@ require (
 	github.com/Azure/go-autorest/autorest/validation v0.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/hashicorp/go-multierror v1.0.0
+	github.com/mitchellh/go-homedir v1.1.0
 	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
 )


### PR DESCRIPTION
Resolves #22.

When Azure CLI authentication is used, there's no refresh token returned from the CLI. Because of that, long-running operations tend to fail.

As a workaround, try reading the refresh token from `~/.azure/accessTokens.json` (or whatever other Azure folder is configured) and finding the refresh token by access token.