### PR TITLE
Support configuring a Tenant ID and ignoring subscriptions

### DIFF
--- a/authentication/auth_method_azure_cli_token.go
+++ b/authentication/auth_method_azure_cli_token.go
@@ -240,6 +240,10 @@ func obtainTenant(tenantId string) (*cli.Subscription, error) {
 				break
 			}
 		}
+
+		if acc.TenantID == "" {
+			return nil, fmt.Errorf("Tenant %q was not found", tenantId)
+		}
 	}
 
 	return &acc, nil

--- a/authentication/auth_method_azure_cli_token.go
+++ b/authentication/auth_method_azure_cli_token.go
@@ -15,12 +15,14 @@ import (
 )
 
 type azureCLIProfile struct {
-	subscription *cli.Subscription
+	// CLI "subscriptions" are really "accounts" that can represent either a subscription (with tenant) or _just_ a tenant
+	account *cli.Subscription
 
 	clientId       string
 	environment    string
 	subscriptionId string
 	tenantId       string
+	tenantOnly     bool
 }
 
 type azureCliTokenAuth struct {
@@ -33,20 +35,32 @@ func (a azureCliTokenAuth) build(b Builder) (authMethod, error) {
 		profile: &azureCLIProfile{
 			subscriptionId: b.SubscriptionID,
 			tenantId:       b.TenantID,
+			tenantOnly:     b.TenantOnly,
 			clientId:       "04b07795-8ddb-461a-bbee-02f9e1bf7b46", // fixed first party client id for Az CLI
 		},
 		servicePrincipalAuthDocsLink: b.ClientSecretDocsLink,
 	}
 
-	sub, err := obtainSubscription(b.SubscriptionID)
-	if err != nil {
-		return nil, fmt.Errorf("obtain subscription(%s) from Azure CLI: %+v", b.SubscriptionID, err)
+	var acc *cli.Subscription
+	if auth.profile.tenantOnly {
+		var err error
+		acc, err = obtainTenant(b.TenantID)
+		if err != nil {
+			return nil, fmt.Errorf("obtain tenant(%s) from Azure CLI: %+v", b.TenantID, err)
+		}
+		auth.profile.account = acc
+	} else {
+		var err error
+		acc, err = obtainSubscription(b.SubscriptionID)
+		if err != nil {
+			return nil, fmt.Errorf("obtain subscription(%s) from Azure CLI: %+v", b.SubscriptionID, err)
+		}
+		auth.profile.account = acc
 	}
-	auth.profile.subscription = sub
 
 	// Authenticating as a Service Principal doesn't return all of the information we need for authentication purposes
 	// as such Service Principal authentication is supported using the specific auth method
-	if sub.User == nil || !strings.EqualFold(sub.User.Type, "user") {
+	if acc.User == nil || !strings.EqualFold(acc.User.Type, "user") {
 		return nil, fmt.Errorf(`Authenticating using the Azure CLI is only supported as a User (not a Service Principal).
 
 To authenticate to Azure using a Service Principal, you can use the separate 'Authenticate using a Service Principal'
@@ -56,14 +70,14 @@ Alternatively you can authenticate using the Azure CLI by using a User Account.`
 	}
 
 	// Populate fields
-	if auth.profile.subscriptionId == "" {
-		auth.profile.subscriptionId = sub.ID
+	if !b.TenantOnly && auth.profile.subscriptionId == "" {
+		auth.profile.subscriptionId = acc.ID
 	}
 	if auth.profile.tenantId == "" {
-		auth.profile.tenantId = sub.TenantID
+		auth.profile.tenantId = acc.TenantID
 	}
 	// always pull the environment from the Azure CLI, since the Access Token's associated with it
-	auth.profile.environment = normalizeEnvironmentName(sub.EnvironmentName)
+	auth.profile.environment = normalizeEnvironmentName(acc.EnvironmentName)
 
 	return auth, nil
 }
@@ -147,7 +161,7 @@ func (a azureCliTokenAuth) validate() error {
 		err = multierror.Append(err, fmt.Errorf(errorMessageFmt, "Client ID"))
 	}
 
-	if a.profile.subscriptionId == "" {
+	if !a.profile.tenantOnly && a.profile.subscriptionId == "" {
 		err = multierror.Append(err, fmt.Errorf(errorMessageFmt, "Subscription ID"))
 	}
 
@@ -182,21 +196,53 @@ func obtainAuthorizationToken(endpoint string, subscriptionId string) (*cli.Toke
 	return &token, nil
 }
 
-// obtainSubscription return a subscription object of the specified subscriptionId.
-// If the subscriptionId is empty, it returns the default subscription.
+// obtainSubscription returns a Subscription object of the specified subscriptionId.
+// If the subscriptionId is empty, it selects the default subscription.
 func obtainSubscription(subscriptionId string) (*cli.Subscription, error) {
-	var sub cli.Subscription
+	var acc cli.Subscription
 	cmd := make([]string, 0)
 	cmd = []string{"account", "show", "-o=json"}
 	if subscriptionId != "" {
 		cmd = append(cmd, "-s", subscriptionId)
 	}
-	err := jsonUnmarshalAzCmd(&sub, cmd...)
+	err := jsonUnmarshalAzCmd(&acc, cmd...)
 	if err != nil {
 		return nil, fmt.Errorf("Error parsing json result from the Azure CLI: %v", err)
 	}
 
-	return &sub, nil
+	return &acc, nil
+}
+
+// obtainTenant returns a Subscription object having the specified tenantId.
+// If the tenantId is empty, it selects the default subscription.
+// This works with `az login --allow-no-subscriptions`
+func obtainTenant(tenantId string) (*cli.Subscription, error) {
+	var acc cli.Subscription
+	if tenantId == "" {
+		cmd := make([]string, 0)
+		cmd = []string{"account", "show", "-o=json"}
+		err := jsonUnmarshalAzCmd(&acc, cmd...)
+		if err != nil {
+			return nil, fmt.Errorf("Error parsing json result from the Azure CLI: %v", err)
+		}
+	} else {
+		var accs []cli.Subscription
+		cmd := make([]string, 0)
+		cmd = []string{"account", "list", "-o=json"}
+		err := jsonUnmarshalAzCmd(&accs, cmd...)
+		if err != nil {
+			return nil, fmt.Errorf("Error parsing json result from the Azure CLI: %v", err)
+		}
+
+		for _, a := range accs {
+			if a.TenantID == tenantId {
+				acc = a
+				break
+			}
+		}
+	}
+
+	return &acc, nil
 }
 
 func jsonUnmarshalAzCmd(i interface{}, arg ...string) error {

--- a/authentication/auth_method_azure_cli_token_test.go
+++ b/authentication/auth_method_azure_cli_token_test.go
@@ -124,6 +124,27 @@ func TestAzureCLITokenAuth_validate(t *testing.T) {
 			},
 			ExpectError: false,
 		},
+		{
+			Description: "Valid TenantOnly Configuration",
+			Config: azureCliTokenAuth{
+				profile: &azureCLIProfile{
+					clientId:   "62e73395-5017-43b6-8ebf-d6c30a514cf1",
+					tenantId:   "9834f8d0-24b3-41b7-8b8d-c611c461a129",
+					tenantOnly: true,
+				},
+			},
+			ExpectError: false,
+		},
+		{
+			Description: "Invalid TenantOnly Configuration",
+			Config: azureCliTokenAuth{
+				profile: &azureCLIProfile{
+					clientId:   "62e73395-5017-43b6-8ebf-d6c30a514cf1",
+					tenantOnly: true,
+				},
+			},
+			ExpectError: true,
+		},
 	}
 
 	for _, v := range cases {

--- a/authentication/auth_method_client_cert.go
+++ b/authentication/auth_method_client_cert.go
@@ -18,6 +18,7 @@ type servicePrincipalClientCertificateAuth struct {
 	clientCertPassword string
 	subscriptionId     string
 	tenantId           string
+	tenantOnly         bool
 }
 
 func (a servicePrincipalClientCertificateAuth) build(b Builder) (authMethod, error) {
@@ -27,6 +28,7 @@ func (a servicePrincipalClientCertificateAuth) build(b Builder) (authMethod, err
 		clientCertPassword: b.ClientCertPassword,
 		subscriptionId:     b.SubscriptionID,
 		tenantId:           b.TenantID,
+		tenantOnly:         b.TenantOnly,
 	}
 	return method, nil
 }
@@ -77,7 +79,7 @@ func (a servicePrincipalClientCertificateAuth) validate() error {
 
 	fmtErrorMessage := "A %s must be configured when authenticating as a Service Principal using a Client Certificate."
 
-	if a.subscriptionId == "" {
+	if !a.tenantOnly && a.subscriptionId == "" {
 		err = multierror.Append(err, fmt.Errorf(fmtErrorMessage, "Subscription ID"))
 	}
 

--- a/authentication/auth_method_client_cert_test.go
+++ b/authentication/auth_method_client_cert_test.go
@@ -206,6 +206,25 @@ func TestServicePrincipalClientCertAuth_validate(t *testing.T) {
 			},
 			ExpectError: false,
 		},
+		{
+			Description: "Invalid TenantOnly Configuration",
+			Config: servicePrincipalClientCertificateAuth{
+				clientId:       "62e73395-5017-43b6-8ebf-d6c30a514cf1",
+				clientCertPath: filePath,
+				tenantOnly:     true,
+			},
+			ExpectError: true,
+		},
+		{
+			Description: "Valid TenantOnly Configuration",
+			Config: servicePrincipalClientCertificateAuth{
+				clientId:       "62e73395-5017-43b6-8ebf-d6c30a514cf1",
+				clientCertPath: filePath,
+				tenantId:       "9834f8d0-24b3-41b7-8b8d-c611c461a129",
+				tenantOnly:     true,
+			},
+			ExpectError: false,
+		},
 	}
 
 	for _, v := range cases {

--- a/authentication/auth_method_client_cert_test.go
+++ b/authentication/auth_method_client_cert_test.go
@@ -209,19 +209,21 @@ func TestServicePrincipalClientCertAuth_validate(t *testing.T) {
 		{
 			Description: "Invalid TenantOnly Configuration",
 			Config: servicePrincipalClientCertificateAuth{
-				clientId:       "62e73395-5017-43b6-8ebf-d6c30a514cf1",
-				clientCertPath: filePath,
-				tenantOnly:     true,
+				clientId:           "62e73395-5017-43b6-8ebf-d6c30a514cf1",
+				clientCertPath:     filePath,
+				clientCertPassword: "123",
+				tenantOnly:         true,
 			},
 			ExpectError: true,
 		},
 		{
 			Description: "Valid TenantOnly Configuration",
 			Config: servicePrincipalClientCertificateAuth{
-				clientId:       "62e73395-5017-43b6-8ebf-d6c30a514cf1",
-				clientCertPath: filePath,
-				tenantId:       "9834f8d0-24b3-41b7-8b8d-c611c461a129",
-				tenantOnly:     true,
+				clientId:           "62e73395-5017-43b6-8ebf-d6c30a514cf1",
+				clientCertPath:     filePath,
+				clientCertPassword: "123",
+				tenantId:           "9834f8d0-24b3-41b7-8b8d-c611c461a129",
+				tenantOnly:         true,
 			},
 			ExpectError: false,
 		},

--- a/authentication/auth_method_client_secret.go
+++ b/authentication/auth_method_client_secret.go
@@ -13,6 +13,7 @@ type servicePrincipalClientSecretAuth struct {
 	clientSecret   string
 	subscriptionId string
 	tenantId       string
+	tenantOnly     bool
 }
 
 func (a servicePrincipalClientSecretAuth) build(b Builder) (authMethod, error) {
@@ -21,6 +22,7 @@ func (a servicePrincipalClientSecretAuth) build(b Builder) (authMethod, error) {
 		clientSecret:   b.ClientSecret,
 		subscriptionId: b.SubscriptionID,
 		tenantId:       b.TenantID,
+		tenantOnly:     b.TenantOnly,
 	}
 	return method, nil
 }
@@ -58,7 +60,7 @@ func (a servicePrincipalClientSecretAuth) validate() error {
 
 	fmtErrorMessage := "A %s must be configured when authenticating as a Service Principal using a Client Secret."
 
-	if a.subscriptionId == "" {
+	if !a.tenantOnly && a.subscriptionId == "" {
 		err = multierror.Append(err, fmt.Errorf(fmtErrorMessage, "Subscription ID"))
 	}
 	if a.clientId == "" {

--- a/authentication/auth_method_client_secret_multi_tenant.go
+++ b/authentication/auth_method_client_secret_multi_tenant.go
@@ -13,6 +13,7 @@ type servicePrincipalClientSecretMultiTenantAuth struct {
 	clientSecret       string
 	subscriptionId     string
 	tenantId           string
+	tenantOnly         bool
 	auxiliaryTenantIDs []string
 }
 
@@ -22,6 +23,7 @@ func (a servicePrincipalClientSecretMultiTenantAuth) build(b Builder) (authMetho
 		clientSecret:       b.ClientSecret,
 		subscriptionId:     b.SubscriptionID,
 		tenantId:           b.TenantID,
+		tenantOnly:         b.TenantOnly,
 		auxiliaryTenantIDs: b.AuxiliaryTenantIDs,
 	}
 	return method, nil
@@ -65,7 +67,7 @@ func (a servicePrincipalClientSecretMultiTenantAuth) validate() error {
 
 	fmtErrorMessage := "A %s must be configured when authenticating as a Service Principal using a Multi Tenant Client Secret."
 
-	if a.subscriptionId == "" {
+	if !a.tenantOnly && a.subscriptionId == "" {
 		err = multierror.Append(err, fmt.Errorf(fmtErrorMessage, "Subscription ID"))
 	}
 	if a.clientId == "" {

--- a/authentication/auth_method_client_secret_multi_tenant_test.go
+++ b/authentication/auth_method_client_secret_multi_tenant_test.go
@@ -193,6 +193,27 @@ func TestServicePrincipalClientSecretMultiTenantAuth_validate(t *testing.T) {
 			},
 			ExpectError: false,
 		},
+		{
+			Description: "Invalid TenantOnly Configuration",
+			Config: servicePrincipalClientSecretMultiTenantAuth{
+				clientId:           "62e73395-5017-43b6-8ebf-d6c30a514cf1",
+				clientSecret:       "Does Hammer Time have Daylight Savings Time?",
+				tenantOnly:         true,
+				auxiliaryTenantIDs: []string{"9834f8d0-0707-1984-bd35-c611c461a129", "9834f8d0-1984-0707-bd35-c611c461a129"},
+			},
+			ExpectError: true,
+		},
+		{
+			Description: "Valid TenantOnly Configuration",
+			Config: servicePrincipalClientSecretMultiTenantAuth{
+				clientId:           "62e73395-5017-43b6-8ebf-d6c30a514cf1",
+				clientSecret:       "Does Hammer Time have Daylight Savings Time?",
+				tenantId:           "9834f8d0-24b3-41b7-8b8d-c611c461a129",
+				tenantOnly:         true,
+				auxiliaryTenantIDs: []string{"9834f8d0-0707-1984-bd35-c611c461a129", "9834f8d0-1984-0707-bd35-c611c461a129"},
+			},
+			ExpectError: false,
+		},
 	}
 
 	for _, v := range cases {

--- a/authentication/auth_method_client_secret_test.go
+++ b/authentication/auth_method_client_secret_test.go
@@ -151,6 +151,25 @@ func TestServicePrincipalClientSecretAuth_validate(t *testing.T) {
 			},
 			ExpectError: false,
 		},
+		{
+			Description: "Invalid TenantOnly Configuration",
+			Config: servicePrincipalClientSecretAuth{
+				clientId:       "62e73395-5017-43b6-8ebf-d6c30a514cf1",
+				clientSecret:   "Does Hammer Time have Daylight Savings Time?",
+				tenantOnly:     true,
+			},
+			ExpectError: true,
+		},
+		{
+			Description: "Valid TenantOnly Configuration",
+			Config: servicePrincipalClientSecretAuth{
+				clientId:       "62e73395-5017-43b6-8ebf-d6c30a514cf1",
+				clientSecret:   "Does Hammer Time have Daylight Savings Time?",
+				tenantId:       "9834f8d0-24b3-41b7-8b8d-c611c461a129",
+				tenantOnly:     true,
+			},
+			ExpectError: false,
+		},
 	}
 
 	for _, v := range cases {

--- a/authentication/builder.go
+++ b/authentication/builder.go
@@ -17,6 +17,7 @@ type Builder struct {
 	ClientID       string
 	SubscriptionID string
 	TenantID       string
+	TenantOnly     bool
 	Environment    string
 	MetadataHost   string
 


### PR DESCRIPTION
Support tenant-only configurations with or without associated subscription(s)

See testing matrix at https://docs.google.com/spreadsheets/d/1HXJrTLPloqsIaZNnv4ynhyy_9X5ibbW4BAG9zr0oCrE

### Changes

* Add a new Builder field `TenantOnly`.
* When true for CLI authentication, locates a suitable CLI 'account' by tenant ID instead of by subscription ID, and `SubscriptionID` is ignored / not required.
* Works with or without the `--allow-no-subscriptions` argument to `az login`.
* Will now support versions of Azure CLI that do or don't populate tenant-level accounts where a linked subscription is found.
* For all auth methods, permits validation without specifying `SubscriptionID`.
* Allows use of modules that don't operate on subscriptions (e.g. graphrbac).

### Related

- https://github.com/terraform-providers/terraform-provider-azuread/issues/294
- https://github.com/terraform-providers/terraform-provider-azuread/issues/314