### PR TITLE
cli auth result depends on exit code

### DIFF
--- a/authentication/auth_method_azure_cli_token.go
+++ b/authentication/auth_method_azure_cli_token.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"os/exec"
 	"strings"
 
@@ -213,16 +214,13 @@ func jsonUnmarshalAzCmd(i interface{}, arg ...string) error {
 	}
 
 	if err := cmd.Wait(); err != nil {
+		if errmsg := stderr.String(); errmsg != "" {
+			log.Printf("[ERROR] Error waiting for the Azure CLI: %s", stderr.String())
+		}
 		return fmt.Errorf("Error waiting for the Azure CLI: %+v", err)
 	}
 
-	stdOutStr := stdout.String()
-	stdErrStr := stderr.String()
-	if stdErrStr != "" {
-		return fmt.Errorf("Error retrieving running Azure CLI: %s", strings.TrimSpace(stdErrStr))
-	}
-
-	if err := json.Unmarshal([]byte(stdOutStr), &i); err != nil {
+	if err := json.Unmarshal([]byte(stdout.String()), &i); err != nil {
 		return fmt.Errorf("Error unmarshaling the result of Azure CLI: %v", err)
 	}
 


### PR DESCRIPTION
Do not simply return when stderr is not empty, since az cli might output warning to stderr. Instead, checking the returned `err` of `cmd.Wait()` is enough to tell whether the command exited with status code 0 or not.

This fixes: terraform-providers/terraform-provider-azurerm#8358