### PR TITLE
Select the correct access token in a multi tenant scenario and subscription ID is not specified

### DIFF
--- a/authentication/auth_method_azure_cli_token.go
+++ b/authentication/auth_method_azure_cli_token.go
@@ -191,8 +191,10 @@ func (a azureCliTokenAuth) validate() error {
 }
 
 func (a azureCliTokenAuth) checkAzVersion() error {
+	// Azure CLI v2.0.79 is the earliest version to have a `version` command
 	var minimumVersion string
 	if a.profile.tenantOnly {
+		// v2.0.81 introduced the `--tenant` option to the `account get-access-token` subcommand
 		minimumVersion = "2.0.81"
 	} else {
 		minimumVersion = "2.0.79"

--- a/authentication/auth_method_azure_cli_token_multi_tenant.go
+++ b/authentication/auth_method_azure_cli_token_multi_tenant.go
@@ -92,7 +92,7 @@ func (a azureCliTokenMultiTenantAuth) getAuthorizationToken(sender autorest.Send
 	}
 
 	var refreshFunc adal.TokenRefresh = func(ctx context.Context, resource string) (*adal.Token, error) {
-		token, err := obtainAuthorizationToken(resource, a.profile.subscriptionId)
+		token, err := obtainAuthorizationToken(resource, a.profile.subscriptionId, "")
 		if err != nil {
 			return nil, err
 		}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/Azure/go-autorest/autorest/validation v0.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/hashicorp/go-multierror v1.0.0
+	github.com/hashicorp/go-version v1.2.1
 	golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897
 )
 

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/U
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
+github.com/hashicorp/go-version v1.2.1 h1:zEfKbn2+PDgroKdiOzqiE8rsmLqU2uwi5PB5pBJ3TkI=
+github.com/hashicorp/go-version v1.2.1/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
Note
- The `-t` argument to `az account get-access-token` is "preview-only"
  but is included in recent releases of azure-cli by default
- Also includes a version check for Azure CLI, returning a detailed error if the available version is too old

Tested on a fresh azure-cli v2.14.0 installation on a new debian VM, with these scenarios: https://docs.google.com/spreadsheets/d/1HXJrTLPloqsIaZNnv4ynhyy_9X5ibbW4BAG9zr0oCrE/edit#gid=0