### PR TITLE
polling: exposing the latest http response from the future

### DIFF
--- a/polling/poller.go
+++ b/polling/poller.go
@@ -9,6 +9,9 @@ import (
 )
 
 type LongRunningPoller struct {
+	// HttpResponse is the latest HTTP Response
+	HttpResponse *http.Response
+
 	future *azure.Future
 	ctx    context.Context
 	client autorest.Client
@@ -30,5 +33,7 @@ func NewLongRunningPollerFromResponse(ctx context.Context, resp *http.Response, 
 
 // PollUntilDone polls until this Long Running Poller is completed
 func (fw *LongRunningPoller) PollUntilDone() error {
-	return fw.future.WaitForCompletionRef(fw.ctx, fw.client)
+	err := fw.future.WaitForCompletionRef(fw.ctx, fw.client)
+	fw.HttpResponse = fw.future.Response()
+	return err
 }


### PR DESCRIPTION
Necessary to replicate this behaviour:

https://github.com/terraform-providers/terraform-provider-azurerm/blob/0a29f734f5406e4772c65b871df5ef871454ab81/azurerm/internal/services/eventhub/eventhub_cluster_resource.go#L173-L176

Since right now we don't have access to the Future's HTTP Response when this fails:

https://github.com/terraform-providers/terraform-provider-azurerm/blob/b2fb4064d30a91fd819e0552cff2cad98205ee08/azurerm/internal/services/eventhub/eventhub_cluster_resource.go#L165-L169