### PR TITLE
Update logging for possible artificial response error 

### DIFF
--- a/sender/sender.go
+++ b/sender/sender.go
@@ -48,6 +48,8 @@ func withRequestLogging(providerName string) autorest.SendDecorator {
 					// fallback to basic message
 					log.Printf("[DEBUG] %s Response: %s for %s\n", providerName, resp.Status, r.URL)
 				}
+			} else if err != nil {
+				log.Printf("[DEBUG] %s Response Error: %s for %s\n", providerName, err, r.URL)
 			} else {
 				log.Printf("[DEBUG] Request to %s completed with no response", r.URL)
 			}


### PR DESCRIPTION
When fixing track2 error https://github.com/Azure/azure-sdk-for-go/issues/14729 , we find that sometimes the response returns nil, but the error is not nil. 