### PR TITLE
resourcemanager: introducing an updated Resource ID Parser based on Segments

### DIFF
--- a/resourcemanager/resourceids/interface.go
+++ b/resourcemanager/resourceids/interface.go
@@ -1,11 +1,125 @@
 package resourceids
 
-// Id defines a type for a ResourceId of some kind
-type Id interface {
+type ResourceId interface {
 	// ID returns the fully formatted ID for this Resource ID
 	ID() string
 
 	// String returns a friendly description of the components of this Resource ID
 	// which is suitable for use in error messages (for example 'MyThing %q / Resource Group %q')
 	String() string
+
+	// Segments returns an ordered list of expected Segments that make up this Resource ID
+	Segments() []Segment
+}
+
+type Segment struct {
+	// ExampleValue is an example of a value for this field, which is intended only to
+	// be used as a placeholder.
+	ExampleValue string
+
+	// FixedValue is the Fixed/Static value for this segment - only present when `Type`
+	// is `ResourceProviderSegmentType` or `StaticSegmentType`.
+	FixedValue *string
+
+	// Name is the camelCased name of this segment, which is normalized (and safe to use as a
+	// parameter/a field if necessary).
+	Name string
+
+	// PossibleValues is a list of possible values for this segment - only present when
+	// `Type` is `ConstantSegmentType`
+	PossibleValues *[]string
+
+	// Type specifies the Type of Segment that this is, for example a `StaticSegmentType`
+	Type SegmentType
+}
+
+type SegmentType string
+
+const (
+	// ConstantSegmentType specifies that this Segment is a Constant
+	ConstantSegmentType SegmentType = "Constant"
+
+	// ResourceGroupSegmentType specifies that this Segment is a Resource Group name
+	ResourceGroupSegmentType SegmentType = "ResourceGroup"
+
+	// ResourceProviderSegmentType specifies that this Segment is a Resource Provider
+	ResourceProviderSegmentType SegmentType = "ResourceProvider"
+
+	// ScopeSegmentType specifies that this Segment is a Scope
+	ScopeSegmentType SegmentType = "Scope"
+
+	// StaticSegmentType specifies that this Segment is a Static/Fixed Value
+	StaticSegmentType SegmentType = "Static"
+
+	// SubscriptionIdSegmentType specifies that this Segment is a Subscription ID
+	SubscriptionIdSegmentType SegmentType = "SubscriptionId"
+
+	// UserSpecifiedSegmentType specifies that this Segment is User-Specifiable
+	UserSpecifiedSegmentType SegmentType = "UserSpecified"
+)
+
+// ConstantSegment is a helper which returns a Segment for a Constant
+func ConstantSegment(name string, possibleValues []string, exampleValue string) Segment {
+	return Segment{
+		Name:           name,
+		PossibleValues: &possibleValues,
+		Type:           ConstantSegmentType,
+		ExampleValue:   exampleValue,
+	}
+}
+
+// ResourceGroupSegment is a helper which returns a Segment for a Resource Group
+func ResourceGroupSegment(name, exampleValue string) Segment {
+	return Segment{
+		Name:         name,
+		Type:         ResourceGroupSegmentType,
+		ExampleValue: exampleValue,
+	}
+}
+
+// ResourceProviderSegment is a helper which returns a Segment for a Resource Provider
+func ResourceProviderSegment(name, resourceProvider, exampleValue string) Segment {
+	return Segment{
+		Name:         name,
+		FixedValue:   &resourceProvider,
+		Type:         ResourceProviderSegmentType,
+		ExampleValue: exampleValue,
+	}
+}
+
+// ScopeSegment is a helper which returns a Segment for a Scope
+func ScopeSegment(name, exampleValue string) Segment {
+	return Segment{
+		Name:         name,
+		Type:         ScopeSegmentType,
+		ExampleValue: exampleValue,
+	}
+}
+
+// StaticSegment is a helper which returns a Segment for a Static Value
+func StaticSegment(name, staticValue, exampleValue string) Segment {
+	return Segment{
+		Name:         name,
+		FixedValue:   &staticValue,
+		Type:         StaticSegmentType,
+		ExampleValue: exampleValue,
+	}
+}
+
+// SubscriptionIdSegment is a helper which returns a Segment for a Subscription Id
+func SubscriptionIdSegment(name, exampleValue string) Segment {
+	return Segment{
+		Name:         name,
+		Type:         SubscriptionIdSegmentType,
+		ExampleValue: exampleValue,
+	}
+}
+
+// UserSpecifiedSegment is a helper which returns a Segment for a User Specified Segment
+func UserSpecifiedSegment(name, exampleValue string) Segment {
+	return Segment{
+		Name:         name,
+		Type:         UserSpecifiedSegmentType,
+		ExampleValue: exampleValue,
+	}
 }

--- a/resourcemanager/resourceids/old.go
+++ b/resourcemanager/resourceids/old.go
@@ -1,0 +1,11 @@
+package resourceids
+
+// Id defines a type for a ResourceId of some kind
+type Id interface {
+	// ID returns the fully formatted ID for this Resource ID
+	ID() string
+
+	// String returns a friendly description of the components of this Resource ID
+	// which is suitable for use in error messages (for example 'MyThing %q / Resource Group %q')
+	String() string
+}

--- a/resourcemanager/resourceids/parse.go
+++ b/resourcemanager/resourceids/parse.go
@@ -1,0 +1,247 @@
+package resourceids
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+type Parser struct {
+	// segments is a slice containing the expected (ordered) segments which
+	// should be present within this Resource ID
+	segments []Segment
+}
+
+// NewParser takes a slice of Segments expected for this Resource ID
+func NewParser(segments []Segment) Parser {
+	return Parser{
+		segments: segments,
+	}
+}
+
+// NewParserFromResourceIdType takes a ResourceId interface and uses its (ordered) Segments
+// to create a Parser which can be used to Parse Resource ID's.
+func NewParserFromResourceIdType(id ResourceId) Parser {
+	segments := id.Segments()
+	return NewParser(segments)
+}
+
+type ParseResult struct {
+	// Parsed is a map of segmentName : segmentValue
+	Parsed map[string]string
+}
+
+// Parse processes a Resource ID and parses it into a ParseResult containing a map of the
+// Known Segments for this Resource ID which callers of this method can then process to
+// form a Resource ID struct of those values doing any type conversions as necessary (for
+//	example, type-casting/converting Constants).
+//
+// `input`: the Resource ID to be parsed, which should match the segments for this Resource ID
+// `insensitively`: should this Resource ID be parsed case-insensitively and fix up any Constant,
+//					Resource Provider and Static Segments to the expected casing.
+func (p Parser) Parse(input string, insensitively bool) (*ParseResult, error) {
+	if input == "" {
+		return nil, fmt.Errorf("cannot parse an empty string")
+	}
+	if len(p.segments) == 0 {
+		return nil, fmt.Errorf("no segments were defined to be able to parse the Resource ID %q", input)
+	}
+
+	// if the entire Resource ID is a Scope
+	if len(p.segments) == 1 && p.segments[0].Type == ScopeSegmentType {
+		return &ParseResult{
+			Parsed: map[string]string{
+				p.segments[0].Name: input,
+			},
+		}, nil
+	}
+
+	parsed := make(map[string]string)
+
+	hasScopeAtStart := p.segments[0].Type == ScopeSegmentType
+	hasScopeAtEnd := p.segments[len(p.segments)-1].Type == ScopeSegmentType
+
+	// go through and build up a regex which will count for the `middle` components of the Resource ID
+	nonScopeComponentsRegex := ""
+	for i, segment := range p.segments {
+		if (i == 0 && hasScopeAtStart) || (i == len(p.segments)-1 && hasScopeAtEnd) {
+			continue
+		}
+
+		switch segment.Type {
+		case ConstantSegmentType:
+			{
+				if segment.PossibleValues == nil {
+					return nil, fmt.Errorf("internal error: constant segment %q had no possible values", segment.Name)
+				}
+
+				// e.g. `/(First|Second|Third)`
+				nonScopeComponentsRegex += fmt.Sprintf("/(%s)", strings.Join(*segment.PossibleValues, "|"))
+				continue
+			}
+
+		case ScopeSegmentType:
+			{
+				return nil, fmt.Errorf("internal error: segment %q is a scope within the middle of a Resource ID which is not supported", segment.Name)
+			}
+
+		case ResourceProviderSegmentType, StaticSegmentType:
+			{
+				if segment.FixedValue == nil {
+					return nil, fmt.Errorf("internal error: segment %q is a static/RP without a fixed value", segment.Name)
+				}
+				nonScopeComponentsRegex += fmt.Sprintf("/%s", *segment.FixedValue)
+				continue
+			}
+
+		case ResourceGroupSegmentType, SubscriptionIdSegmentType, UserSpecifiedSegmentType:
+			{
+				nonScopeComponentsRegex += "/(.){1,}"
+				continue
+			}
+		}
+	}
+
+	var scopePrefix string
+	if hasScopeAtStart {
+		prefix, err := p.parseScopePrefix(input, nonScopeComponentsRegex, insensitively)
+		if err != nil {
+			return nil, fmt.Errorf("parsing scope prefix: %+v", err)
+		}
+
+		scopePrefix = *prefix
+		parsed[p.segments[0].Name] = *prefix
+	}
+
+	// trim off the scopePrefix and the leading `/` to give us the segments we expect plus the final scope string
+	// at the end, if present
+	uri := input
+	if hasScopeAtStart {
+		uri = strings.TrimPrefix(uri, scopePrefix)
+		uri = strings.TrimPrefix(uri, "/")
+
+		// add a fake start so that the indexes match when we loop around, else we're updating the index below
+		uri = fmt.Sprintf("fakestart/%s", uri)
+	}
+
+	uri = strings.TrimPrefix(uri, "/")
+	split := strings.Split(uri, "/")
+	segmentCount := len(split)
+	if segmentCount < len(p.segments) {
+		return nil, fmt.Errorf("expected %d segments within the Resource ID but got %d for %q", len(p.segments), segmentCount, input)
+	}
+
+	if hasScopeAtStart {
+		// trim off the fake start since we use any remaining uri as a suffixScope
+		uri = strings.TrimPrefix(uri, "fakestart/")
+	}
+
+	for i, segment := range p.segments {
+		if (i == 0 && hasScopeAtStart) || (i == len(p.segments)-1 && hasScopeAtEnd) {
+			continue
+		}
+
+		// as we go around each of the segments we're expecting, process the value we should surface
+		rawSegment := split[i]
+		value, err := p.parseSegment(segment, rawSegment, insensitively)
+		if err != nil {
+			return nil, fmt.Errorf("parsing segment %q: %+v", segment.Name, err)
+		}
+		parsed[segment.Name] = *value
+
+		// and then remove rawSegment from `uri` so that any leftovers is the scope
+		// since if there's a scope there'll be more segments than we expect
+		uri = strings.TrimPrefix(uri, fmt.Sprintf("%s", rawSegment))
+		uri = strings.TrimPrefix(uri, "/")
+	}
+
+	if uri != "" {
+		if !hasScopeAtEnd {
+			return nil, fmt.Errorf("unexpected segment %q present at the end of the URI (input %q)", uri, input)
+		}
+
+		parsed[p.segments[len(p.segments)-1].Name] = fmt.Sprintf("/%s", uri)
+	}
+
+	if len(p.segments) != len(parsed) {
+		return nil, fmt.Errorf("expected %d segments but got %d for %q", len(p.segments), len(parsed), input)
+	}
+
+	return &ParseResult{
+		Parsed: parsed,
+	}, nil
+}
+
+func (p Parser) parseScopePrefix(input, regexForNonScopeSegments string, insensitively bool) (*string, error) {
+	regexToUse := fmt.Sprintf("^((.){1,})%s", regexForNonScopeSegments)
+	if insensitively {
+		regexToUse = fmt.Sprintf("(?i)%s", regexToUse)
+	}
+	r, err := regexp.Compile(regexToUse)
+	if err != nil {
+		return nil, fmt.Errorf("internal error: compiling regex %q to find scope prefix: %+v", regexToUse, err)
+	}
+	// 0 is the entire string, 1 will be the scope prefix, we can ignore the rest
+	values := r.FindStringSubmatch(input)
+	if len(values) < 2 {
+		return nil, fmt.Errorf("unable to find the scope prefix from the value %q with the regex %q", input, regexToUse)
+	}
+	v := values[1]
+	if v == "" {
+		return nil, fmt.Errorf("unable to find the scope prefix from the value %q using the regex %q", input, regexToUse)
+	}
+	return &v, nil
+}
+
+func (p Parser) parseSegment(segment Segment, rawValue string, insensitively bool) (*string, error) {
+	switch segment.Type {
+	case ConstantSegmentType:
+		{
+			if segment.PossibleValues == nil {
+				return nil, fmt.Errorf("internal error: missing PossibleValues for Constant segment %q", segment.Name)
+			}
+			for _, possibleVal := range *segment.PossibleValues {
+				matches := possibleVal == rawValue
+				if insensitively {
+					matches = strings.EqualFold(possibleVal, rawValue)
+				}
+
+				if matches {
+					return &possibleVal, nil
+				}
+			}
+
+			return nil, fmt.Errorf("expected the segment %q to match one of the values %q but got %q", segment.Name, strings.Join(*segment.PossibleValues, ", "), rawValue)
+		}
+
+	case ResourceProviderSegmentType, StaticSegmentType:
+		{
+			if segment.FixedValue == nil {
+				return nil, fmt.Errorf("internal error: segment %q is a static/RP segment without a fixed value", segment.Name)
+			}
+
+			matches := *segment.FixedValue == rawValue
+			if insensitively {
+				matches = strings.EqualFold(*segment.FixedValue, rawValue)
+			}
+
+			if matches {
+				return &*segment.FixedValue, nil
+			}
+
+			return nil, fmt.Errorf("expected the segment %q to be %q", rawValue, *segment.FixedValue)
+		}
+
+	case ScopeSegmentType:
+		{
+			return nil, fmt.Errorf("internal error: scope segments aren't supported unless at the start or the end")
+		}
+
+	case ResourceGroupSegmentType, SubscriptionIdSegmentType, UserSpecifiedSegmentType:
+		{
+			return &rawValue, nil
+		}
+	}
+
+	return nil, fmt.Errorf("internal error: missing parser for segment %q (type %q)", segment.Name, string(segment.Type))
+}

--- a/resourcemanager/resourceids/parse_test.go
+++ b/resourcemanager/resourceids/parse_test.go
@@ -1,0 +1,941 @@
+package resourceids
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseEmptyId(t *testing.T) {
+	t.Logf("Sensitively")
+	actual, err := NewParser([]Segment{}).Parse("", false)
+	if err == nil {
+		t.Fatalf("expected an error but didn't get one")
+	}
+	if actual != nil {
+		t.Fatalf("got a parse result but didn't expect one: %+v", *actual)
+	}
+
+	t.Logf("Insensitively")
+	actual, err = NewParser([]Segment{}).Parse("", true)
+	if err == nil {
+		t.Fatalf("expected an error but didn't get one")
+	}
+	if actual != nil {
+		t.Fatalf("got a parse result but didn't expect one: %+v", *actual)
+	}
+}
+
+func TestParseStaticId(t *testing.T) {
+	testData := []struct {
+		name          string
+		segments      []Segment
+		expected      *ParseResult
+		input         string
+		insensitively bool
+	}{
+		{
+			name: "single segment sensitive",
+			segments: []Segment{
+				StaticSegment("hello", "hello", "example"),
+			},
+			expected: &ParseResult{
+				map[string]string{
+					"hello": "hello",
+				},
+			},
+			input:         "/hello",
+			insensitively: false,
+		},
+		{
+			name: "single segment insensitive",
+			segments: []Segment{
+				StaticSegment("hello", "hello", "example"),
+			},
+			expected: &ParseResult{
+				map[string]string{
+					"hello": "hello",
+				},
+			},
+			input:         "/Hello",
+			insensitively: true,
+		},
+		{
+			name: "multiple segments sensitive",
+			segments: []Segment{
+				StaticSegment("hello", "hello", "example"),
+				StaticSegment("there", "there", "example"),
+			},
+			expected: &ParseResult{
+				map[string]string{
+					"hello": "hello",
+					"there": "there",
+				},
+			},
+			input:         "/hello/there",
+			insensitively: false,
+		},
+		{
+			name: "multiple segments sensitive",
+			segments: []Segment{
+				StaticSegment("hello", "hello", "example"),
+				StaticSegment("there", "there", "example"),
+			},
+			expected: &ParseResult{
+				map[string]string{
+					"hello": "hello",
+					"there": "there",
+				},
+			},
+			input:         "/Hello/tHere",
+			insensitively: true,
+		},
+	}
+	for _, test := range testData {
+		t.Logf("Test %q..", test.name)
+		parser := NewParser(test.segments)
+		actual, err := parser.Parse(test.input, test.insensitively)
+		validateResult(t, actual, test.expected, err)
+	}
+}
+
+func TestParseResourceGroupId(t *testing.T) {
+	segments := []Segment{
+		StaticSegment("subscriptions", "subscriptions", "example"),
+		SubscriptionIdSegment("subscriptionId", "example"),
+		StaticSegment("resourceGroups", "resourceGroups", "example"),
+		ResourceGroupSegment("resourceGroupName", "example"),
+	}
+	testData := []struct {
+		name        string
+		input       string
+		expected    *ParseResult
+		insensitive bool
+	}{
+		{
+			name:        "empty id - sensitive",
+			input:       "",
+			insensitive: false,
+		},
+		{
+			name:        "empty id - insensitive",
+			input:       "",
+			insensitive: true,
+		},
+		{
+			name:        "empty slash - sensitive",
+			input:       "/",
+			insensitive: false,
+		},
+		{
+			name:        "empty slash - insensitive",
+			input:       "/",
+			insensitive: true,
+		},
+		{
+			name:        "subscription id - sensitive",
+			input:       "/subscriptions/11112222-3333-4444-555566667777",
+			insensitive: false,
+		},
+		{
+			name:        "subscription id - insensitive",
+			input:       "/subscRiptions/11112222-3333-4444-555566667777",
+			insensitive: true,
+		},
+		{
+			name:        "resource groups list - sensitive",
+			input:       "/subscriptions/11112222-3333-4444-555566667777/resourceGroups",
+			insensitive: false,
+		},
+		{
+			name:        "resource groups list - insensitive",
+			input:       "/subscriptions/11112222-3333-4444-555566667777/resourcegroups",
+			insensitive: true,
+		},
+		{
+			name:        "resource group id - sensitive",
+			input:       "/subscriptions/11112222-3333-4444-555566667777/resourceGroups/BoB",
+			insensitive: false,
+			expected: &ParseResult{
+				map[string]string{
+					"subscriptions":     "subscriptions",
+					"subscriptionId":    "11112222-3333-4444-555566667777",
+					"resourceGroups":    "resourceGroups",
+					"resourceGroupName": "BoB",
+				},
+			},
+		},
+		{
+			name:        "resource groups id - insensitive",
+			input:       "/subscRiptions/11112222-3333-4444-555566667777/resourcegroups/BoB",
+			insensitive: true,
+			expected: &ParseResult{
+				map[string]string{
+					"subscriptions":     "subscriptions",
+					"subscriptionId":    "11112222-3333-4444-555566667777",
+					"resourceGroups":    "resourceGroups",
+					"resourceGroupName": "BoB",
+				},
+			},
+		},
+	}
+	for _, test := range testData {
+		t.Logf("Test %q..", test.name)
+		parser := NewParser(segments)
+		actual, err := parser.Parse(test.input, test.insensitive)
+		validateResult(t, actual, test.expected, err)
+	}
+}
+
+func TestParseVirtualMachineId(t *testing.T) {
+	segments := []Segment{
+		StaticSegment("subscriptions", "subscriptions", "example"),
+		SubscriptionIdSegment("subscriptionId", "example"),
+		StaticSegment("resourceGroups", "resourceGroups", "example"),
+		ResourceGroupSegment("resourceGroupName", "example"),
+		StaticSegment("providers", "providers", "example"),
+		ResourceProviderSegment("provider", "Microsoft.Compute", "example"),
+		StaticSegment("virtualMachines", "virtualMachines", "example"),
+		UserSpecifiedSegment("virtualMachineName", "example"),
+	}
+	testData := []struct {
+		name        string
+		input       string
+		expected    *ParseResult
+		insensitive bool
+	}{
+		{
+			name:        "resource group id - sensitive",
+			input:       "/subscriptions/11112222-3333-4444-555566667777/resourceGroups/BoB",
+			insensitive: false,
+		},
+		{
+			name:        "resource groups id - insensitive",
+			input:       "/subscRiptions/11112222-3333-4444-555566667777/resourcegroups/BoB",
+			insensitive: true,
+		},
+		{
+			name:        "resource providers list - sensitive",
+			input:       "/subscriptions/11112222-3333-4444-555566667777/resourceGroups/BoB/providers",
+			insensitive: false,
+		},
+		{
+			name:        "resource providers list - insensitive",
+			input:       "/subscRiptions/11112222-3333-4444-555566667777/resourcegroups/BoB/proViders",
+			insensitive: true,
+		},
+		{
+			name:        "resource provider name - sensitive",
+			input:       "/subscriptions/11112222-3333-4444-555566667777/resourceGroups/BoB/providers/Microsoft.Compute",
+			insensitive: false,
+		},
+		{
+			name:        "resource provider name - insensitive",
+			input:       "/subscRiptions/11112222-3333-4444-555566667777/resourcegroups/BoB/proViders/Microsoft.compute",
+			insensitive: true,
+		},
+		{
+			name:        "virtual machine list - sensitive",
+			input:       "/subscriptions/11112222-3333-4444-555566667777/resourceGroups/BoB/providers/Microsoft.Compute/virtualMachines",
+			insensitive: false,
+		},
+		{
+			name:        "virtual machine list - insensitive",
+			input:       "/subscRiptions/11112222-3333-4444-555566667777/resourcegroups/BoB/proViders/Microsoft.compute/virtualmachines",
+			insensitive: true,
+		},
+		{
+			name:        "virtual machine id - sensitive",
+			input:       "/subscriptions/11112222-3333-4444-555566667777/resourceGroups/BoB/providers/Microsoft.Compute/virtualMachines/machine1",
+			insensitive: false,
+			expected: &ParseResult{
+				map[string]string{
+					"subscriptions":      "subscriptions",
+					"subscriptionId":     "11112222-3333-4444-555566667777",
+					"resourceGroups":     "resourceGroups",
+					"resourceGroupName":  "BoB",
+					"providers":          "providers",
+					"provider":           "Microsoft.Compute",
+					"virtualMachines":    "virtualMachines",
+					"virtualMachineName": "machine1",
+				},
+			},
+		},
+		{
+			name:        "virtual machine id - insensitive",
+			input:       "/subScriptions/11112222-3333-4444-555566667777/resourcegroups/BoB/pRoviders/microsoft.Compute/virtualmachines/machine1",
+			insensitive: true,
+			expected: &ParseResult{
+				map[string]string{
+					"subscriptions":      "subscriptions",
+					"subscriptionId":     "11112222-3333-4444-555566667777",
+					"resourceGroups":     "resourceGroups",
+					"resourceGroupName":  "BoB",
+					"providers":          "providers",
+					"provider":           "Microsoft.Compute",
+					"virtualMachines":    "virtualMachines",
+					"virtualMachineName": "machine1",
+				},
+			},
+		},
+		{
+			name:        "virtual machine extension id - sensitive",
+			input:       "/subscriptions/11112222-3333-4444-555566667777/resourceGroups/BoB/providers/Microsoft.Compute/virtualMachines/machine1/extensions/extension1",
+			insensitive: false,
+		},
+		{
+			name:        "virtual machine extension id - insensitive",
+			input:       "/subScriptions/11112222-3333-4444-555566667777/resourcegroups/BoB/pRoviders/microsoft.Compute/virtualmachines/machine1/extenSions/extension1",
+			insensitive: true,
+		},
+	}
+	for _, test := range testData {
+		t.Logf("Test %q..", test.name)
+		parser := NewParser(segments)
+		actual, err := parser.Parse(test.input, test.insensitive)
+		validateResult(t, actual, test.expected, err)
+	}
+}
+
+func TestParseVirtualMachineExtensionId(t *testing.T) {
+	segments := []Segment{
+		StaticSegment("subscriptions", "subscriptions", "example"),
+		SubscriptionIdSegment("subscriptionId", "example"),
+		StaticSegment("resourceGroups", "resourceGroups", "example"),
+		ResourceGroupSegment("resourceGroupName", "example"),
+		StaticSegment("providers", "providers", "example"),
+		ResourceProviderSegment("provider", "Microsoft.Compute", "example"),
+		StaticSegment("virtualMachines", "virtualMachines", "example"),
+		UserSpecifiedSegment("virtualMachineName", "example"),
+		StaticSegment("extensions", "extensions", "example"),
+		UserSpecifiedSegment("extensionName", "example"),
+	}
+	testData := []struct {
+		name        string
+		input       string
+		expected    *ParseResult
+		insensitive bool
+	}{
+		{
+			name:        "virtual machine id - sensitive",
+			input:       "/subscriptions/11112222-3333-4444-555566667777/resourceGroups/BoB/providers/Microsoft.Compute/virtualMachines/machine1",
+			insensitive: false,
+		},
+		{
+			name:        "virtual machine id - insensitive",
+			input:       "/subScriptions/11112222-3333-4444-555566667777/resourcegroups/BoB/pRoviders/microsoft.Compute/virtualmachines/machine1",
+			insensitive: true,
+		},
+		{
+			name:        "virtual machine extensions list - sensitive",
+			input:       "/subscriptions/11112222-3333-4444-555566667777/resourceGroups/BoB/providers/Microsoft.Compute/virtualMachines/machine1/extensions",
+			insensitive: false,
+		},
+		{
+			name:        "virtual machine extensions list - insensitive",
+			input:       "/subScriptions/11112222-3333-4444-555566667777/resourcegroups/BoB/pRoviders/microsoft.Compute/virtualmachines/machine1/extensions",
+			insensitive: true,
+		},
+
+		{
+			name:        "virtual machine extension id - sensitive",
+			input:       "/subscriptions/11112222-3333-4444-555566667777/resourceGroups/BoB/providers/Microsoft.Compute/virtualMachines/machine1/extensions/extension1",
+			insensitive: false,
+			expected: &ParseResult{
+				map[string]string{
+					"subscriptions":      "subscriptions",
+					"subscriptionId":     "11112222-3333-4444-555566667777",
+					"resourceGroups":     "resourceGroups",
+					"resourceGroupName":  "BoB",
+					"providers":          "providers",
+					"provider":           "Microsoft.Compute",
+					"virtualMachines":    "virtualMachines",
+					"virtualMachineName": "machine1",
+					"extensions":         "extensions",
+					"extensionName":      "extension1",
+				},
+			},
+		},
+		{
+			name:        "resource groups id - insensitive",
+			input:       "/subScriptions/11112222-3333-4444-555566667777/resourcegroups/BoB/pRoviders/microsoft.Compute/virtualmachines/machine1/exTensions/extension1",
+			insensitive: true,
+			expected: &ParseResult{
+				map[string]string{
+					"subscriptions":      "subscriptions",
+					"subscriptionId":     "11112222-3333-4444-555566667777",
+					"resourceGroups":     "resourceGroups",
+					"resourceGroupName":  "BoB",
+					"providers":          "providers",
+					"provider":           "Microsoft.Compute",
+					"virtualMachines":    "virtualMachines",
+					"virtualMachineName": "machine1",
+					"extensions":         "extensions",
+					"extensionName":      "extension1",
+				},
+			},
+		},
+	}
+	for _, test := range testData {
+		t.Logf("Test %q..", test.name)
+		parser := NewParser(segments)
+		actual, err := parser.Parse(test.input, test.insensitive)
+		validateResult(t, actual, test.expected, err)
+	}
+}
+
+func TestParseAdvancedThreatProtectionId(t *testing.T) {
+	segments := []Segment{
+		ScopeSegment("scope", "example"),
+		StaticSegment("providers", "providers", "example"),
+		ResourceProviderSegment("provider", "Microsoft.Security", "example"),
+		StaticSegment("advancedThreatProtectionSettings", "advancedThreatProtectionSettings", "example"),
+		UserSpecifiedSegment("name", "example"),
+	}
+	testData := []struct {
+		name        string
+		input       string
+		expected    *ParseResult
+		insensitive bool
+	}{
+		{
+			name:        "resource group id - sensitive",
+			input:       "/subscriptions/11112222-3333-4444-555566667777/resourceGroups/BoB/providers/Microsoft.Security/advancedThreatProtectionSettings/someName",
+			insensitive: false,
+			expected: &ParseResult{
+				map[string]string{
+					"scope":                            "/subscriptions/11112222-3333-4444-555566667777/resourceGroups/BoB",
+					"providers":                        "providers",
+					"provider":                         "Microsoft.Security",
+					"advancedThreatProtectionSettings": "advancedThreatProtectionSettings",
+					"name":                             "someName",
+				},
+			},
+		},
+		{
+			name:        "resource group id - sensitive invalid",
+			input:       "/subscripTions/11112222-3333-4444-555566667777/resourcEgroups/BoB/proviDers/Microsoft.security/advancedthreatProtectionSettings/someName",
+			insensitive: false,
+		},
+		{
+			name:        "resource group id - insensitive",
+			input:       "/subscripTions/11112222-3333-4444-555566667777/resourcEgroups/BoB/proviDers/Microsoft.security/advancedthreatProtectionSettings/someName",
+			insensitive: true,
+			expected: &ParseResult{
+				map[string]string{
+					"scope":                            "/subscripTions/11112222-3333-4444-555566667777/resourcEgroups/BoB",
+					"providers":                        "providers",
+					"provider":                         "Microsoft.Security",
+					"advancedThreatProtectionSettings": "advancedThreatProtectionSettings",
+					"name":                             "someName",
+				},
+			},
+		},
+		{
+			name:        "resource group id - sensitive w/extra",
+			input:       "/subscriptions/11112222-3333-4444-555566667777/resourceGroups/BoB/providers/Microsoft.Security/advancedThreatProtectionSettings/someName/extra",
+			insensitive: false,
+		},
+		{
+			name:        "resource group id - insensitive w/extra",
+			input:       "/subscriptions/11112222-3333-4444-555566667777/resourceGroups/BoB/providers/Microsoft.Security/advancedThreatProtectionSettings/someName/extra",
+			insensitive: true,
+		},
+		{
+			name:        "virtual machine id - sensitive",
+			input:       "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/virtualMachines/machine1/providers/Microsoft.Security/advancedThreatProtectionSettings/someName",
+			insensitive: false,
+			expected: &ParseResult{
+				map[string]string{
+					"scope":                            "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/virtualMachines/machine1",
+					"providers":                        "providers",
+					"provider":                         "Microsoft.Security",
+					"advancedThreatProtectionSettings": "advancedThreatProtectionSettings",
+					"name":                             "someName",
+				},
+			},
+		},
+		{
+			name:        "virtual machine id - sensitive invalid",
+			input:       "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/virtualMachines/machine1/Providers/Microsoft.SecuRity/advancedThreatprotectionSettings/someName",
+			insensitive: false,
+		},
+		{
+			name:        "virtual machine id - insensitive",
+			input:       "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/virtualMachines/machine1/Providers/Microsoft.SecuRity/advancedThreatprotectionSettings/someName",
+			insensitive: true,
+			expected: &ParseResult{
+				map[string]string{
+					"scope":                            "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Compute/virtualMachines/machine1",
+					"providers":                        "providers",
+					"provider":                         "Microsoft.Security",
+					"advancedThreatProtectionSettings": "advancedThreatProtectionSettings",
+					"name":                             "someName",
+				},
+			},
+		},
+	}
+	for _, test := range testData {
+		t.Logf("Test %q..", test.name)
+		parser := NewParser(segments)
+		actual, err := parser.Parse(test.input, test.insensitive)
+		validateResult(t, actual, test.expected, err)
+	}
+}
+
+func TestParseIdContainingAConstant(t *testing.T) {
+	segments := []Segment{
+		StaticSegment("planets", "planets", "example"),
+		ConstantSegment("planetName", []string{"Mars", "Earth"}, "example"),
+	}
+	testData := []struct {
+		name        string
+		input       string
+		expected    *ParseResult
+		insensitive bool
+	}{
+		{
+			name:        "planets - top level - sensitive",
+			input:       "/planets",
+			insensitive: false,
+		},
+		{
+			name:        "planets - top level - insensitive",
+			input:       "/plaNets",
+			insensitive: true,
+		},
+		{
+			name:        "planets - earth - sensitive",
+			input:       "/planets/Earth",
+			insensitive: false,
+			expected: &ParseResult{
+				map[string]string{
+					"planets":    "planets",
+					"planetName": "Earth",
+				},
+			},
+		},
+		{
+			name:        "planets - earth - insensitive",
+			input:       "/planets/earth",
+			insensitive: true,
+			expected: &ParseResult{
+				map[string]string{
+					"planets":    "planets",
+					"planetName": "Earth",
+				},
+			},
+		},
+		{
+			name:        "planets - mars - sensitive",
+			input:       "/planets/Mars",
+			insensitive: false,
+			expected: &ParseResult{
+				map[string]string{
+					"planets":    "planets",
+					"planetName": "Mars",
+				},
+			},
+		},
+		{
+			name:        "planets - mars - insensitive",
+			input:       "/planets/mars",
+			insensitive: true,
+			expected: &ParseResult{
+				map[string]string{
+					"planets":    "planets",
+					"planetName": "Mars",
+				},
+			},
+		},
+		{
+			name:        "planets - Pluto (invalid) - sensitive",
+			input:       "/planets/Pluto",
+			insensitive: false,
+		},
+		{
+			name:        "planets - Pluto (invalid) - insensitive",
+			input:       "/planets/pluto",
+			insensitive: true,
+		},
+	}
+	for _, test := range testData {
+		t.Logf("Test %q..", test.name)
+		parser := NewParser(segments)
+		actual, err := parser.Parse(test.input, test.insensitive)
+		validateResult(t, actual, test.expected, err)
+	}
+}
+
+func TestParseIdContainingAScopePrefix(t *testing.T) {
+	segments := []Segment{
+		ScopeSegment("scope", "example"),
+		StaticSegment("extensions", "extensions", "example"),
+		UserSpecifiedSegment("extensionName", "example"),
+	}
+	testData := []struct {
+		name        string
+		input       string
+		expected    *ParseResult
+		insensitive bool
+	}{
+		{
+			name:        "missing scope - sensitive",
+			input:       "/extensions/bob",
+			insensitive: false,
+		},
+		{
+			name:        "missing scope - insensitive",
+			input:       "/extenSions/bob",
+			insensitive: true,
+		},
+		{
+			name:        "scope - single level - sensitive",
+			input:       "/planets/extensions/terraform",
+			insensitive: false,
+			expected: &ParseResult{
+				map[string]string{
+					"scope":         "/planets",
+					"extensions":    "extensions",
+					"extensionName": "terraform",
+				},
+			},
+		},
+		{
+			name:        "scope - single level - insensitive",
+			input:       "/planets/extenSions/terraform",
+			insensitive: true,
+			expected: &ParseResult{
+				map[string]string{
+					"scope":         "/planets",
+					"extensions":    "extensions",
+					"extensionName": "terraform",
+				},
+			},
+		},
+		{
+			name:        "scope - multiple level - sensitive",
+			input:       "/solarSystems/milkyWay/planets/mars/extensions/terraform",
+			insensitive: false,
+			expected: &ParseResult{
+				map[string]string{
+					"scope":         "/solarSystems/milkyWay/planets/mars",
+					"extensions":    "extensions",
+					"extensionName": "terraform",
+				},
+			},
+		},
+		{
+			name:        "scope - multiple level - insensitive",
+			input:       "/solarSystems/milkyWay/planets/mars/extenSions/terraform",
+			insensitive: true,
+			expected: &ParseResult{
+				map[string]string{
+					"scope":         "/solarSystems/milkyWay/planets/mars",
+					"extensions":    "extensions",
+					"extensionName": "terraform",
+				},
+			},
+		},
+	}
+	for _, test := range testData {
+		t.Logf("Test %q..", test.name)
+		parser := NewParser(segments)
+		actual, err := parser.Parse(test.input, test.insensitive)
+		validateResult(t, actual, test.expected, err)
+	}
+}
+
+func TestParseIdContainingAScopeSuffix(t *testing.T) {
+	segments := []Segment{
+		StaticSegment("subscriptions", "subscriptions", "example"),
+		SubscriptionIdSegment("subscriptionId", "example"),
+		ScopeSegment("scope", "example"),
+	}
+	testData := []struct {
+		name        string
+		input       string
+		expected    *ParseResult
+		insensitive bool
+	}{
+		{
+			name:        "missing scope - sensitive",
+			input:       "/subscriptions/1111",
+			insensitive: false,
+		},
+		{
+			name:        "missing scope - insensitive",
+			input:       "/subscriPtions/1111",
+			insensitive: true,
+		},
+		{
+			name:        "scope - single level - sensitive",
+			input:       "/subscriptions/1111/someThing",
+			insensitive: false,
+			expected: &ParseResult{
+				map[string]string{
+					"scope":          "/someThing",
+					"subscriptions":  "subscriptions",
+					"subscriptionId": "1111",
+				},
+			},
+		},
+		{
+			name:        "scope - single level - insensitive",
+			input:       "/subscrIptions/1111/someThing",
+			insensitive: true,
+			expected: &ParseResult{
+				map[string]string{
+					"scope":          "/someThing",
+					"subscriptions":  "subscriptions",
+					"subscriptionId": "1111",
+				},
+			},
+		},
+		{
+			name:        "scope - multiple level - sensitive",
+			input:       "/subscriptions/1111/solarSystems/milkyWay/planets/mars",
+			insensitive: false,
+			expected: &ParseResult{
+				map[string]string{
+					"scope":          "/solarSystems/milkyWay/planets/mars",
+					"subscriptions":  "subscriptions",
+					"subscriptionId": "1111",
+				},
+			},
+		},
+		{
+			name:        "scope - multiple level - insensitive",
+			input:       "/subscriPtions/1111/solarSystems/milkyWay/planets/mars",
+			insensitive: true,
+			expected: &ParseResult{
+				map[string]string{
+					"scope":          "/solarSystems/milkyWay/planets/mars",
+					"subscriptions":  "subscriptions",
+					"subscriptionId": "1111",
+				},
+			},
+		},
+	}
+	for _, test := range testData {
+		t.Logf("Test %q..", test.name)
+		parser := NewParser(segments)
+		actual, err := parser.Parse(test.input, test.insensitive)
+		validateResult(t, actual, test.expected, err)
+	}
+}
+
+func TestParseIdContainingAScopeEitherEnd(t *testing.T) {
+	segments := []Segment{
+		ScopeSegment("start", "example"),
+		StaticSegment("connections", "connections", "example"),
+		SubscriptionIdSegment("connectionName", "example"),
+		ScopeSegment("end", "example"),
+	}
+	testData := []struct {
+		name        string
+		input       string
+		expected    *ParseResult
+		insensitive bool
+	}{
+		{
+			name:        "missing start - sensitive",
+			input:       "/connections/BER-FCO/someOtherThing",
+			insensitive: false,
+		},
+		{
+			name:        "missing start - insensitive",
+			input:       "/connecTions/BER-FCO/someOtherThing",
+			insensitive: true,
+		},
+		{
+			name:        "missing end - sensitive",
+			input:       "/someThing/connections/BER-FCO",
+			insensitive: false,
+		},
+		{
+			name:        "missing end - insensitive",
+			input:       "/someThing/connEctions/BER-FCO",
+			insensitive: true,
+		},
+		{
+			name:        "missing both ends - sensitive",
+			input:       "/connections/BER-FCO",
+			insensitive: false,
+		},
+		{
+			name:        "missing both ends - insensitive",
+			input:       "/connectiOns/BER-FCO",
+			insensitive: true,
+		},
+		{
+			name:        "scope - single level - sensitive",
+			input:       "/someThing/connections/BER-FCO/someOtherThing",
+			insensitive: false,
+			expected: &ParseResult{
+				map[string]string{
+					"connectionName": "BER-FCO",
+					"connections":    "connections",
+					"end":            "/someOtherThing",
+					"start":          "/someThing",
+				},
+			},
+		},
+		{
+			name:        "scope - single level - insensitive",
+			input:       "/someThing/Connections/BER-FCO/someOtherThing",
+			insensitive: true,
+			expected: &ParseResult{
+				map[string]string{
+					"connectionName": "BER-FCO",
+					"connections":    "connections",
+					"end":            "/someOtherThing",
+					"start":          "/someThing",
+				},
+			},
+		},
+		{
+			name:        "scope - multiple level - sensitive",
+			input:       "/someThing/thats/really/awesome/connections/BER-FCO/someOtherThing/woah",
+			insensitive: false,
+			expected: &ParseResult{
+				map[string]string{
+					"connectionName": "BER-FCO",
+					"connections":    "connections",
+					"end":            "/someOtherThing/woah",
+					"start":          "/someThing/thats/really/awesome",
+				},
+			},
+		},
+		{
+			name:        "scope - multiple level - insensitive",
+			input:       "/someThing/thats/really/awesome/conNections/BER-FCO/someOtherThing/woah",
+			insensitive: true,
+			expected: &ParseResult{
+				map[string]string{
+					"connectionName": "BER-FCO",
+					"connections":    "connections",
+					"end":            "/someOtherThing/woah",
+					"start":          "/someThing/thats/really/awesome",
+				},
+			},
+		},
+	}
+	for _, test := range testData {
+		t.Logf("Test %q..", test.name)
+		parser := NewParser(segments)
+		actual, err := parser.Parse(test.input, test.insensitive)
+		validateResult(t, actual, test.expected, err)
+	}
+}
+
+func TestParseIdContainingJustAScope(t *testing.T) {
+	segments := []Segment{
+		ScopeSegment("scope", "example"),
+	}
+	testData := []struct {
+		name        string
+		input       string
+		expected    *ParseResult
+		insensitive bool
+	}{
+		{
+			name:        "empty",
+			input:       "",
+			insensitive: false,
+		},
+		{
+			name:        "slash - sensitive",
+			input:       "/",
+			insensitive: false,
+			expected: &ParseResult{
+				map[string]string{
+					"scope": "/",
+				},
+			},
+		},
+		{
+			name:        "slash - insensitive",
+			input:       "/",
+			insensitive: true,
+			expected: &ParseResult{
+				map[string]string{
+					"scope": "/",
+				},
+			},
+		},
+		{
+			name:        "single level - sensitive",
+			input:       "/hello",
+			insensitive: false,
+			expected: &ParseResult{
+				map[string]string{
+					"scope": "/hello",
+				},
+			},
+		},
+		{
+			name:        "single level - insensitive",
+			input:       "/hello",
+			insensitive: true,
+			expected: &ParseResult{
+				map[string]string{
+					"scope": "/hello",
+				},
+			},
+		},
+		{
+			name:        "multiple levels - sensitive",
+			input:       "/hello/there/world",
+			insensitive: false,
+			expected: &ParseResult{
+				map[string]string{
+					"scope": "/hello/there/world",
+				},
+			},
+		},
+		{
+			name:        "multiple levels - insensitive",
+			input:       "/hello/there/world",
+			insensitive: true,
+			expected: &ParseResult{
+				map[string]string{
+					"scope": "/hello/there/world",
+				},
+			},
+		},
+	}
+	for _, test := range testData {
+		t.Logf("Test %q..", test.name)
+		parser := NewParser(segments)
+		actual, err := parser.Parse(test.input, test.insensitive)
+		validateResult(t, actual, test.expected, err)
+	}
+}
+
+func validateResult(t *testing.T, actual *ParseResult, expected *ParseResult, err error) {
+	if err != nil {
+		if expected == nil {
+			return
+		}
+
+		t.Fatalf("got an error but didn't expect one: %+v", err)
+	}
+	if expected == nil {
+		t.Fatalf("expected an error but didn't get one")
+	}
+
+	if expected == nil && actual == nil {
+		return
+	}
+
+	if actual == nil {
+		t.Fatalf("expected a parse result but didn't get one")
+	}
+	if expected == nil {
+		t.Fatalf("expected no parse result but got %+v", actual.Parsed)
+	}
+
+	if !reflect.DeepEqual(expected.Parsed, actual.Parsed) {
+		t.Fatalf("Diff between Expected and Actual.\n\nExpected: %+v\n\nActual: %+v", expected.Parsed, actual.Parsed)
+	}
+}


### PR DESCRIPTION
This allows the parsing of Resource ID's which contain Scopes either at the start or the end - but not in the middle (since we've not seen any) - as such this should be fine.

This means that Resource ID's now need to expose a slice of expected segments, for example:

```go
func (id ConfigurationStoreId) ID() string {
	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.AppConfiguration/configurationStores/%s"
	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.ConfigStoreName)
}

func (id ConfigurationStoreId) Segments() []resourceids.Segment {
	return []resourceids.Segments{
		resourceids.StaticSegment("subscriptions", "subscriptions", "exampleValue"),
		resourceids.SubscriptionIdSegment("subscriptionId", "exampleValue"),
		resourceids.StaticSegment("resourceGroups", "resourceGroups", "exampleValue"),
		resourceids.ResourceGroupSegment("resourceGroupName", "exampleValue"),
		resourceids.StaticSegment("providers", "providers", "exampleValue"),
		resourceids.ResourceProviderSegment("microsoftAppConfiguration", "Microsoft.AppConfiguration", "exampleValue"),
		resourceids.StaticSegment("configurationStores", "configurationStores", "exampleValue"),
		resourceids.UserSpecifiedSegment("configStoreName", "exampleValue"),
	}
}
```

This PR's based on the work done by @koikonom but instead uses a regex to find any Prefix Scope, then parses the segments we expect (based on the `Segments()` function above) - and finally raises an error if there's any unexpected values present / uses any remainder as the Suffix Scope if applicable.

Notably the `insensitive` version of this parser will case-correct any static segments to match what we're expecting, which whilst isn't perfect - should help normalise some of the API casing issues as Terraform Core requires these are byte-for-byte compatible.