### PR TITLE
resourcemanager/tags: Flatten now returns map[string]interface{}

### DIFF
--- a/resourcemanager/tags/expand.go
+++ b/resourcemanager/tags/expand.go
@@ -1,5 +1,6 @@
 package tags
 
+// Expand transforms the input Tags to a `*map[string]string`
 func Expand(input map[string]interface{}) *map[string]string {
 	output := make(map[string]string)
 

--- a/resourcemanager/tags/expand.go
+++ b/resourcemanager/tags/expand.go
@@ -4,7 +4,9 @@ func Expand(input map[string]interface{}) *map[string]string {
 	output := make(map[string]string)
 
 	for k, v := range input {
-		output[k] = v.(string)
+		tagKey := k
+		tagValue := v.(string)
+		output[tagKey] = tagValue
 	}
 
 	return &output

--- a/resourcemanager/tags/flatten.go
+++ b/resourcemanager/tags/flatten.go
@@ -1,5 +1,12 @@
 package tags
 
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// Flatten transforms the Tags specified via `input` into a map[string]interface{}
+// for compatibility with the Schema.
 func Flatten(input *map[string]string) map[string]interface{} {
 	output := make(map[string]interface{})
 	if input == nil {
@@ -13,4 +20,16 @@ func Flatten(input *map[string]string) map[string]interface{} {
 	}
 
 	return output
+}
+
+// FlattenAndSet first Flatten's the Tags and then sets the flattened value into
+// the `tags` field in the State.
+func FlattenAndSet(d *schema.ResourceData, input *map[string]string) error {
+	tags := Flatten(input)
+
+	if err := d.Set("tags", tags); err != nil {
+		return fmt.Errorf("setting `tags`: %+v", err)
+	}
+
+	return nil
 }

--- a/resourcemanager/tags/flatten.go
+++ b/resourcemanager/tags/flatten.go
@@ -1,17 +1,15 @@
 package tags
 
-import (
-	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-)
-
-func Flatten(input *map[string]string) map[string]*string {
-	output := make(map[string]*string)
+func Flatten(input *map[string]string) map[string]interface{} {
+	output := make(map[string]interface{})
 	if input == nil {
 		return output
 	}
 
 	for k, v := range *input {
-		output[k] = pointer.FromString(v)
+		tagKey := k
+		tagValue := v
+		output[tagKey] = tagValue
 	}
 
 	return output


### PR DESCRIPTION
This enables this to be used directly in Read functions rather than having an intermediate translation function.