### PR TITLE
identity: refactoring to be Required, Optional and Computed

### DIFF
--- a/resourcemanager/commonschema/identity_system.go
+++ b/resourcemanager/commonschema/identity_system.go
@@ -7,7 +7,36 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-func SystemAssignedIdentity() *schema.Schema {
+// SystemAssignedIdentityRequired returns the System Assigned Identity schema where this is Required
+func SystemAssignedIdentityRequired() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Required: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"type": {
+					Type:     schema.TypeString,
+					Required: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						string(identity.TypeSystemAssigned),
+					}, false),
+				},
+				"principal_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"tenant_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			},
+		},
+	}
+}
+
+// SystemAssignedIdentityOptional returns the System Assigned Identity schema where this is Optional
+func SystemAssignedIdentityOptional() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
@@ -34,7 +63,8 @@ func SystemAssignedIdentity() *schema.Schema {
 	}
 }
 
-func SystemAssignedIdentityDataSource() *schema.Schema {
+// SystemAssignedIdentityOptional returns the System Assigned Identity schema where this is Computed
+func SystemAssignedIdentityComputed() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Computed: true,

--- a/resourcemanager/commonschema/identity_system_or_user.go
+++ b/resourcemanager/commonschema/identity_system_or_user.go
@@ -13,7 +13,45 @@ import (
 // from a users perspective however, these should both be represented using the same schema
 // so we have a single schema and separate Expand/Flatten functions
 
-func SystemOrUserAssignedIdentity() *schema.Schema {
+// SystemOrUserAssignedIdentityRequired returns the System or User Assigned Identity schema where this is Required
+func SystemOrUserAssignedIdentityRequired() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Required: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"type": {
+					Type:     schema.TypeString,
+					Required: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						string(identity.TypeUserAssigned),
+						string(identity.TypeSystemAssigned),
+					}, false),
+				},
+				"identity_ids": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Schema{
+						Type:         schema.TypeString,
+						ValidateFunc: commonids.ValidateUserAssignedIdentityID,
+					},
+				},
+				"principal_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"tenant_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			},
+		},
+	}
+}
+
+// SystemOrUserAssignedIdentityOptional returns the System or User Assigned Identity schema where this is Optional
+func SystemOrUserAssignedIdentityOptional() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
@@ -49,7 +87,8 @@ func SystemOrUserAssignedIdentity() *schema.Schema {
 	}
 }
 
-func SystemOrUserAssignedIdentityDataSource() *schema.Schema {
+// SystemOrUserAssignedIdentityComputed returns the System or User Assigned Identity schema where this is Computed
+func SystemOrUserAssignedIdentityComputed() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Computed: true,

--- a/resourcemanager/commonschema/identity_system_user.go
+++ b/resourcemanager/commonschema/identity_system_user.go
@@ -13,7 +13,46 @@ import (
 // from a users perspective however, these should both be represented using the same schema
 // so we have a single schema and separate Expand/Flatten functions
 
-func SystemAssignedUserAssignedIdentity() *schema.Schema {
+// SystemAssignedUserAssignedIdentityRequired returns the System Assigned User Assigned Identity schema where this is Required
+func SystemAssignedUserAssignedIdentityRequired() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Required: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"type": {
+					Type:     schema.TypeString,
+					Required: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						string(identity.TypeUserAssigned),
+						string(identity.TypeSystemAssigned),
+						string(identity.TypeSystemAssignedUserAssigned),
+					}, false),
+				},
+				"identity_ids": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Schema{
+						Type:         schema.TypeString,
+						ValidateFunc: commonids.ValidateUserAssignedIdentityID,
+					},
+				},
+				"principal_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"tenant_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			},
+		},
+	}
+}
+
+// SystemAssignedUserAssignedIdentityOptional returns the System Assigned User Assigned Identity schema where this is Optional
+func SystemAssignedUserAssignedIdentityOptional() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
@@ -50,7 +89,8 @@ func SystemAssignedUserAssignedIdentity() *schema.Schema {
 	}
 }
 
-func SystemAssignedUserAssignedIdentityDataSource() *schema.Schema {
+// SystemAssignedUserAssignedIdentityComputed returns the System Assigned User Assigned Identity schema where this is Computed
+func SystemAssignedUserAssignedIdentityComputed() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Computed: true,

--- a/resourcemanager/commonschema/identity_user.go
+++ b/resourcemanager/commonschema/identity_user.go
@@ -7,7 +7,36 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-func UserAssignedIdentity() *schema.Schema {
+// UserAssignedIdentityRequired returns the User Assigned Identity schema where this is Required
+func UserAssignedIdentityRequired() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Required: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"type": {
+					Type:     schema.TypeString,
+					Required: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						string(identity.TypeUserAssigned),
+					}, false),
+				},
+				"identity_ids": {
+					Type:     schema.TypeSet,
+					Required: true,
+					Elem: &schema.Schema{
+						Type:         schema.TypeString,
+						ValidateFunc: commonids.ValidateUserAssignedIdentityID,
+					},
+				},
+			},
+		},
+	}
+}
+
+// UserAssignedIdentityOptional returns the User Assigned Identity schema where this is Optional
+func UserAssignedIdentityOptional() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
@@ -34,7 +63,8 @@ func UserAssignedIdentity() *schema.Schema {
 	}
 }
 
-func UserAssignedIdentityDataSource() *schema.Schema {
+// UserAssignedIdentityComputed returns the User Assigned Identity schema where this is Computed
+func UserAssignedIdentityComputed() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Computed: true,


### PR DESCRIPTION
We need to support where Identity is both Required, Optional and Computed - however whilst doing so I realised that adding a `{Name}Required` function would differ from the schema used in Resource Groups and Location where the Required method is the default, so this PR refactors the identity function to take this into account.