### PR TITLE
resourcemanager/identity: normalizing the casing of the `type`

### DIFF
--- a/resourcemanager/identity/constants.go
+++ b/resourcemanager/identity/constants.go
@@ -1,5 +1,7 @@
 package identity
 
+import "strings"
+
 type Type string
 
 const (
@@ -8,3 +10,18 @@ const (
 	TypeUserAssigned               Type = "UserAssigned"
 	TypeSystemAssignedUserAssigned Type = "SystemAssigned, UserAssigned"
 )
+
+func normalizeType(input Type) Type {
+	vals := []Type{
+		TypeNone,
+		TypeSystemAssigned,
+		TypeUserAssigned,
+		TypeSystemAssignedUserAssigned,
+	}
+	for _, v := range vals {
+		if strings.EqualFold(string(input), string(v)) {
+			return v
+		}
+	}
+	return input
+}

--- a/resourcemanager/identity/system_and_user_assigned_list.go
+++ b/resourcemanager/identity/system_and_user_assigned_list.go
@@ -3,7 +3,6 @@ package identity
 import (
 	"encoding/json"
 	"fmt"
-
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -81,7 +80,12 @@ func ExpandSystemAndUserAssignedList(input []interface{}) (*SystemAndUserAssigne
 
 // FlattenSystemAndUserAssignedList turns a SystemAndUserAssignedList into a []interface{}
 func FlattenSystemAndUserAssignedList(input *SystemAndUserAssignedList) (*[]interface{}, error) {
-	if input == nil || (input.Type != TypeSystemAssigned && input.Type != TypeSystemAssignedUserAssigned && input.Type != TypeUserAssigned) {
+	if input == nil {
+		return &[]interface{}{}, nil
+	}
+
+	input.Type = normalizeType(input.Type)
+	if input.Type != TypeSystemAssigned && input.Type != TypeSystemAssignedUserAssigned && input.Type != TypeUserAssigned {
 		return &[]interface{}{}, nil
 	}
 

--- a/resourcemanager/identity/system_and_user_assigned_map.go
+++ b/resourcemanager/identity/system_and_user_assigned_map.go
@@ -83,7 +83,13 @@ func ExpandSystemAndUserAssignedMap(input []interface{}) (*SystemAndUserAssigned
 
 // FlattenSystemAndUserAssignedMap turns a SystemAndUserAssignedMap into a []interface{}
 func FlattenSystemAndUserAssignedMap(input *SystemAndUserAssignedMap) (*[]interface{}, error) {
-	if input == nil || (input.Type != TypeSystemAssigned && input.Type != TypeSystemAssignedUserAssigned && input.Type != TypeUserAssigned) {
+	if input == nil {
+		return &[]interface{}{}, nil
+	}
+
+	input.Type = normalizeType(input.Type)
+
+	if input.Type != TypeSystemAssigned && input.Type != TypeSystemAssignedUserAssigned && input.Type != TypeUserAssigned {
 		return &[]interface{}{}, nil
 	}
 

--- a/resourcemanager/identity/system_assigned.go
+++ b/resourcemanager/identity/system_assigned.go
@@ -2,7 +2,6 @@ package identity
 
 import (
 	"encoding/json"
-	"strings"
 )
 
 var _ json.Marshaler = &SystemAssigned{}
@@ -37,7 +36,13 @@ func ExpandSystemAssigned(input []interface{}) (*SystemAssigned, error) {
 }
 
 func FlattenSystemAssigned(input *SystemAssigned) []interface{} {
-	if input == nil || strings.EqualFold(string(input.Type), string(TypeNone)) {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	input.Type = normalizeType(input.Type)
+
+	if input.Type == TypeNone {
 		return []interface{}{}
 	}
 

--- a/resourcemanager/identity/system_or_user_assigned_list.go
+++ b/resourcemanager/identity/system_or_user_assigned_list.go
@@ -42,7 +42,7 @@ func (s *SystemOrUserAssignedList) MarshalJSON() ([]byte, error) {
 	return json.Marshal(out)
 }
 
-// ExpandSystemOrAssignedUserAssignedList expands the schema input into a SystemOrUserAssignedList struct
+// ExpandSystemOrUserAssignedList expands the schema input into a SystemOrUserAssignedList struct
 func ExpandSystemOrUserAssignedList(input []interface{}) (*SystemOrUserAssignedList, error) {
 	identityType := TypeNone
 	identityIds := make([]string, 0)
@@ -75,7 +75,12 @@ func ExpandSystemOrUserAssignedList(input []interface{}) (*SystemOrUserAssignedL
 
 // FlattenSystemAssignedOrUserAssignedList turns a SystemOrUserAssignedList into a []interface{}
 func FlattenSystemAssignedOrUserAssignedList(input *SystemOrUserAssignedList) (*[]interface{}, error) {
-	if input == nil || (input.Type != TypeSystemAssigned && input.Type != TypeUserAssigned) {
+	if input == nil {
+		return &[]interface{}{}, nil
+	}
+
+	input.Type = normalizeType(input.Type)
+	if input.Type != TypeSystemAssigned && input.Type != TypeUserAssigned {
 		return &[]interface{}{}, nil
 	}
 

--- a/resourcemanager/identity/system_or_user_assigned_map.go
+++ b/resourcemanager/identity/system_or_user_assigned_map.go
@@ -77,7 +77,12 @@ func ExpandSystemOrUserAssignedMap(input []interface{}) (*SystemOrUserAssignedMa
 
 // FlattenSystemOrUserAssignedMap turns a SystemOrUserAssignedMap into a []interface{}
 func FlattenSystemOrUserAssignedMap(input *SystemOrUserAssignedMap) (*[]interface{}, error) {
-	if input == nil || (input.Type != TypeSystemAssigned && input.Type != TypeUserAssigned) {
+	if input == nil {
+		return &[]interface{}{}, nil
+	}
+
+	input.Type = normalizeType(input.Type)
+	if input.Type != TypeSystemAssigned && input.Type != TypeUserAssigned {
 		return &[]interface{}{}, nil
 	}
 

--- a/resourcemanager/identity/user_assigned_list.go
+++ b/resourcemanager/identity/user_assigned_list.go
@@ -65,7 +65,13 @@ func ExpandUserAssignedList(input []interface{}) (*UserAssignedList, error) {
 
 // FlattenUserAssignedList turns a UserAssignedList into a []interface{}
 func FlattenUserAssignedList(input *UserAssignedList) (*[]interface{}, error) {
-	if input == nil || input.Type != TypeUserAssigned {
+	if input == nil {
+		return &[]interface{}{}, nil
+	}
+
+	input.Type = normalizeType(input.Type)
+
+	if input.Type != TypeUserAssigned {
 		return &[]interface{}{}, nil
 	}
 

--- a/resourcemanager/identity/user_assigned_map.go
+++ b/resourcemanager/identity/user_assigned_map.go
@@ -66,7 +66,13 @@ func ExpandUserAssignedMap(input []interface{}) (*UserAssignedMap, error) {
 
 // FlattenUserAssignedMap turns a UserAssignedMap into a []interface{}
 func FlattenUserAssignedMap(input *UserAssignedMap) (*[]interface{}, error) {
-	if input == nil || input.Type != TypeUserAssigned {
+	if input == nil {
+		return &[]interface{}{}, nil
+	}
+
+	input.Type = normalizeType(input.Type)
+
+	if input.Type != TypeUserAssigned {
 		return &[]interface{}{}, nil
 	}
 


### PR DESCRIPTION
This works around an issue where the API specifies one case but returns another, such as in https://github.com/Azure/azure-rest-api-specs/issues/12330 - as such these should be parsed insensitively when coming back from the API