### PR TITLE
resourcemanager/commonschema: adding support for Edge Zones

### DIFF
--- a/resourcemanager/commonschema/edge_zone.go
+++ b/resourcemanager/commonschema/edge_zone.go
@@ -1,0 +1,38 @@
+package commonschema
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/edgezones"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+// EdgeZoneComputed returns the schema for an Edge Zone which is Computed
+func EdgeZoneComputed() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeString,
+		Computed: true,
+	}
+}
+
+// EdgeZoneOptional returns the schema for an Edge Zone which is Optional
+func EdgeZoneOptional() *schema.Schema {
+	return &schema.Schema{
+		Type:             schema.TypeString,
+		Optional:         true,
+		ValidateFunc:     validation.StringIsNotEmpty,
+		StateFunc:        edgezones.StateFunc,
+		DiffSuppressFunc: edgezones.DiffSuppressFunc,
+	}
+}
+
+// EdgeZoneOptionalForceNew returns the schema for an Edge Zone which is both Optional and ForceNew
+func EdgeZoneOptionalForceNew() *schema.Schema {
+	return &schema.Schema{
+		Type:             schema.TypeString,
+		Optional:         true,
+		ForceNew:         true,
+		ValidateFunc:     validation.StringIsNotEmpty,
+		StateFunc:        edgezones.StateFunc,
+		DiffSuppressFunc: edgezones.DiffSuppressFunc,
+	}
+}

--- a/resourcemanager/edgezones/normalize.go
+++ b/resourcemanager/edgezones/normalize.go
@@ -1,0 +1,21 @@
+package edgezones
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+)
+
+// Normalize transforms the specified user input into a canonical form
+func Normalize(input string) string {
+	// we're intentionally passing through to Locations today since this is sufficient
+	// but it's helpful to have a specific endpoint for this should this need to change
+	// in the future
+	return location.Normalize(input)
+}
+
+// NormalizeNilable normalizes the specified user input into a canonical form
+func NormalizeNilable(input *string) string {
+	// we're intentionally passing through to Locations today since this is sufficient
+	// but it's helpful to have a specific endpoint for this should this need to change
+	// in the future
+	return location.NormalizeNilable(input)
+}

--- a/resourcemanager/edgezones/normalize_test.go
+++ b/resourcemanager/edgezones/normalize_test.go
@@ -1,0 +1,57 @@
+package edgezones
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+)
+
+func TestNormalizeLocation(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected string
+	}{
+		{
+			input:    "MicrosoftLosAngeles1",
+			expected: "microsoftlosangeles1",
+		},
+		{
+			input:    "Microsoft Los Angeles 1",
+			expected: "microsoftlosangeles1",
+		},
+	}
+
+	for _, v := range cases {
+		actual := Normalize(v.input)
+		if v.expected != actual {
+			t.Fatalf("Expected %q but got %q", v.expected, actual)
+		}
+	}
+}
+
+func TestNormalizeNilableLocation(t *testing.T) {
+	cases := []struct {
+		input    *string
+		expected string
+	}{
+		{
+			input:    pointer.FromString("MicrosoftLosAngeles1"),
+			expected: "microsoftlosangeles1",
+		},
+		{
+			input:    pointer.FromString("Microsoft Los Angeles 1"),
+			expected: "microsoftlosangeles1",
+		},
+		{
+			input:    nil,
+			expected: "",
+		},
+	}
+
+	for _, v := range cases {
+		actual := NormalizeNilable(v.input)
+		if v.expected != actual {
+			t.Fatalf("Expected %q but got %q", v.expected, actual)
+		}
+	}
+}

--- a/resourcemanager/edgezones/schema.go
+++ b/resourcemanager/edgezones/schema.go
@@ -1,0 +1,12 @@
+package edgezones
+
+import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+func DiffSuppressFunc(_, old, new string, _ *schema.ResourceData) bool {
+	return Normalize(old) == Normalize(new)
+}
+
+func StateFunc(location interface{}) string {
+	input := location.(string)
+	return Normalize(input)
+}


### PR DESCRIPTION
These are intended to be used as `edge_zone = commonschema.EdgeZoneOptional()`

At this time we intentionally only support Optional, OptionalForceNew and Computed as these are the use-cases - however we may expand this to support Required in future.

Supersedes #97