### PR TITLE
Bugfix: add compatiblity for ADAL tokens in auth.Config.MSALBearerAuthorizerCallback()

### DIFF
--- a/authentication/config.go
+++ b/authentication/config.go
@@ -134,6 +134,13 @@ func (c Config) MSALBearerAuthorizerCallback(ctx context.Context, api environmen
 		})
 	}
 
+	// For compatibility with Azure CLI which still uses ADAL, first check if we got an autorest.BearerAuthorizer
+	if cast, ok := authorizer.(*autorest.BearerAuthorizer); ok {
+		return autorest.NewBearerAuthorizerCallback(sender, func(_, _ string) (*autorest.BearerAuthorizer, error) {
+			return cast, nil
+		})
+	}
+
 	cast, ok := authorizer.(*auth.CachedAuthorizer)
 	if !ok {
 		return autorest.NewBearerAuthorizerCallback(nil, func(_, _ string) (*autorest.BearerAuthorizer, error) {


### PR DESCRIPTION
Ensure that tokens returned via Azure CLI or MSI authentication will still work for data plane APIs, because those both return legacy ADAL tokens.