### PR TITLE
Identity: Add expand/flatten from/to the typed schema model

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -243,7 +243,6 @@ github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
-github.com/manicminer/hamilton v0.43.0 h1:X/XrzLWFhPx1mlLBycqgKRcIjM9vfCd/QR5YnJKIDTI=
 github.com/manicminer/hamilton v0.43.0/go.mod h1:lbVyngC+/nCWuDp8UhC6Bw+bh7jcP/E+YwqzHTmzemk=
 github.com/manicminer/hamilton v0.44.0 h1:mLb4Vxbt2dsAvOpaB7xd/5D8LaTTX6ACwVP4TmW8qwE=
 github.com/manicminer/hamilton v0.44.0/go.mod h1:lbVyngC+/nCWuDp8UhC6Bw+bh7jcP/E+YwqzHTmzemk=

--- a/resourcemanager/identity/system_and_user_assigned_list.go
+++ b/resourcemanager/identity/system_and_user_assigned_list.go
@@ -114,7 +114,7 @@ func ExpandSystemAndUserAssignedListFromModel(input []ModelSystemAssignedUserAss
 	if len(input) == 0 {
 		return &SystemAndUserAssignedList{
 			Type:        TypeNone,
-			IdentityIds: []string{},
+			IdentityIds: nil,
 		}, nil
 	}
 

--- a/resourcemanager/identity/system_and_user_assigned_list.go
+++ b/resourcemanager/identity/system_and_user_assigned_list.go
@@ -130,8 +130,8 @@ func ExpandSystemAndUserAssignedListFromModel(input []ModelSystemAssignedUserAss
 	}, nil
 }
 
-// FlattenSystemAndUserAssignedListFromModel turns a SystemAndUserAssignedList into a typed schema model
-func FlattenSystemAndUserAssignedListFromModel(input *SystemAndUserAssignedList) (*[]ModelSystemAssignedUserAssigned, error) {
+// FlattenSystemAndUserAssignedListToModel turns a SystemAndUserAssignedList into a typed schema model
+func FlattenSystemAndUserAssignedListToModel(input *SystemAndUserAssignedList) (*[]ModelSystemAssignedUserAssigned, error) {
 	if input == nil {
 		return &[]ModelSystemAssignedUserAssigned{}, nil
 	}

--- a/resourcemanager/identity/system_and_user_assigned_list.go
+++ b/resourcemanager/identity/system_and_user_assigned_list.go
@@ -108,3 +108,54 @@ func FlattenSystemAndUserAssignedList(input *SystemAndUserAssignedList) (*[]inte
 		},
 	}, nil
 }
+
+// ExpandSystemAndUserAssignedListFromModel expands the typed schema input into a SystemAndUserAssignedList struct
+func ExpandSystemAndUserAssignedListFromModel(input []ModelSystemAssignedUserAssigned) (*SystemAndUserAssignedList, error) {
+	if len(input) == 0 {
+		return &SystemAndUserAssignedList{
+			Type:        TypeNone,
+			IdentityIds: []string{},
+		}, nil
+	}
+
+	identity := input[0]
+
+	if len(identity.IdentityIds) > 0 && (identity.Type != TypeSystemAssignedUserAssigned && identity.Type != TypeUserAssigned) {
+		return nil, fmt.Errorf("`identity_ids` can only be specified when `type` is set to %q or %q", TypeSystemAssignedUserAssigned, TypeUserAssigned)
+	}
+
+	return &SystemAndUserAssignedList{
+		Type:        identity.Type,
+		IdentityIds: identity.IdentityIds,
+	}, nil
+}
+
+// FlattenSystemAndUserAssignedListFromModel turns a SystemAndUserAssignedList into a typed schema model
+func FlattenSystemAndUserAssignedListFromModel(input *SystemAndUserAssignedList) (*[]ModelSystemAssignedUserAssigned, error) {
+	if input == nil {
+		return &[]ModelSystemAssignedUserAssigned{}, nil
+	}
+
+	input.Type = normalizeType(input.Type)
+	if input.Type != TypeSystemAssigned && input.Type != TypeSystemAssignedUserAssigned && input.Type != TypeUserAssigned {
+		return &[]ModelSystemAssignedUserAssigned{}, nil
+	}
+
+	identityIds := make([]string, 0)
+	for _, raw := range input.IdentityIds {
+		id, err := commonids.ParseUserAssignedIdentityIDInsensitively(raw)
+		if err != nil {
+			return nil, fmt.Errorf("parsing %q as a User Assigned Identity ID: %+v", raw, err)
+		}
+		identityIds = append(identityIds, id.ID())
+	}
+
+	return &[]ModelSystemAssignedUserAssigned{
+		{
+			Type:        input.Type,
+			IdentityIds: identityIds,
+			PrincipalId: input.PrincipalId,
+			TenantId:    input.TenantId,
+		},
+	}, nil
+}

--- a/resourcemanager/identity/system_and_user_assigned_map.go
+++ b/resourcemanager/identity/system_and_user_assigned_map.go
@@ -111,3 +111,61 @@ func FlattenSystemAndUserAssignedMap(input *SystemAndUserAssignedMap) (*[]interf
 		},
 	}, nil
 }
+
+// ExpandSystemAndUserAssignedMapFromModel expands the typed schema input into a SystemAndUserAssignedMap struct
+func ExpandSystemAndUserAssignedMapFromModel(input []ModelSystemAssignedUserAssigned) (*SystemAndUserAssignedMap, error) {
+	if len(input) == 0 {
+		return &SystemAndUserAssignedMap{
+			Type:        TypeNone,
+			IdentityIds: map[string]UserAssignedIdentityDetails{},
+		}, nil
+	}
+
+	identity := input[0]
+
+	identityIds := make(map[string]UserAssignedIdentityDetails, len(identity.IdentityIds))
+	for _, v := range identity.IdentityIds {
+		identityIds[v] = UserAssignedIdentityDetails{
+			// intentionally empty since the expand shouldn't send these values
+		}
+	}
+	if len(identityIds) > 0 && (identity.Type != TypeSystemAssignedUserAssigned && identity.Type != TypeUserAssigned) {
+		return nil, fmt.Errorf("`identity_ids` can only be specified when `type` is set to %q or %q", TypeSystemAssignedUserAssigned, TypeUserAssigned)
+	}
+
+	return &SystemAndUserAssignedMap{
+		Type:        identity.Type,
+		IdentityIds: identityIds,
+	}, nil
+}
+
+// FlattenSystemAndUserAssignedMapFromModel turns a SystemAndUserAssignedMap into a typed schema model
+func FlattenSystemAndUserAssignedMapFromModel(input *SystemAndUserAssignedMap) (*[]ModelSystemAssignedUserAssigned, error) {
+	if input == nil {
+		return &[]ModelSystemAssignedUserAssigned{}, nil
+	}
+
+	input.Type = normalizeType(input.Type)
+
+	if input.Type != TypeSystemAssigned && input.Type != TypeSystemAssignedUserAssigned && input.Type != TypeUserAssigned {
+		return &[]ModelSystemAssignedUserAssigned{}, nil
+	}
+
+	identityIds := make([]string, 0)
+	for raw := range input.IdentityIds {
+		id, err := commonids.ParseUserAssignedIdentityIDInsensitively(raw)
+		if err != nil {
+			return nil, fmt.Errorf("parsing %q as a User Assigned Identity ID: %+v", raw, err)
+		}
+		identityIds = append(identityIds, id.ID())
+	}
+
+	return &[]ModelSystemAssignedUserAssigned{
+		{
+			Type:        input.Type,
+			IdentityIds: identityIds,
+			PrincipalId: input.PrincipalId,
+			TenantId:    input.TenantId,
+		},
+	}, nil
+}

--- a/resourcemanager/identity/system_and_user_assigned_map.go
+++ b/resourcemanager/identity/system_and_user_assigned_map.go
@@ -139,8 +139,8 @@ func ExpandSystemAndUserAssignedMapFromModel(input []ModelSystemAssignedUserAssi
 	}, nil
 }
 
-// FlattenSystemAndUserAssignedMapFromModel turns a SystemAndUserAssignedMap into a typed schema model
-func FlattenSystemAndUserAssignedMapFromModel(input *SystemAndUserAssignedMap) (*[]ModelSystemAssignedUserAssigned, error) {
+// FlattenSystemAndUserAssignedMapToModel turns a SystemAndUserAssignedMap into a typed schema model
+func FlattenSystemAndUserAssignedMapToModel(input *SystemAndUserAssignedMap) (*[]ModelSystemAssignedUserAssigned, error) {
 	if input == nil {
 		return &[]ModelSystemAssignedUserAssigned{}, nil
 	}

--- a/resourcemanager/identity/system_and_user_assigned_map.go
+++ b/resourcemanager/identity/system_and_user_assigned_map.go
@@ -117,7 +117,7 @@ func ExpandSystemAndUserAssignedMapFromModel(input []ModelSystemAssignedUserAssi
 	if len(input) == 0 {
 		return &SystemAndUserAssignedMap{
 			Type:        TypeNone,
-			IdentityIds: map[string]UserAssignedIdentityDetails{},
+			IdentityIds: nil,
 		}, nil
 	}
 

--- a/resourcemanager/identity/system_assigned.go
+++ b/resourcemanager/identity/system_assigned.go
@@ -54,3 +54,35 @@ func FlattenSystemAssigned(input *SystemAssigned) []interface{} {
 		},
 	}
 }
+
+func ExpandSystemAssignedFromModel(input []ModelSystemAssigned) (*SystemAssigned, error) {
+	if len(input) == 0 {
+		return &SystemAssigned{
+			Type: TypeNone,
+		}, nil
+	}
+
+	return &SystemAssigned{
+		Type: TypeSystemAssigned,
+	}, nil
+}
+
+func FlattenSystemAssignedFromModel(input *SystemAssigned) []ModelSystemAssigned {
+	if input == nil {
+		return []ModelSystemAssigned{}
+	}
+
+	input.Type = normalizeType(input.Type)
+
+	if input.Type == TypeNone {
+		return []ModelSystemAssigned{}
+	}
+
+	return []ModelSystemAssigned{
+		{
+			Type:        input.Type,
+			PrincipalId: input.PrincipalId,
+			TenantId:    input.TenantId,
+		},
+	}
+}

--- a/resourcemanager/identity/system_assigned.go
+++ b/resourcemanager/identity/system_assigned.go
@@ -67,7 +67,7 @@ func ExpandSystemAssignedFromModel(input []ModelSystemAssigned) (*SystemAssigned
 	}, nil
 }
 
-func FlattenSystemAssignedFromModel(input *SystemAssigned) []ModelSystemAssigned {
+func FlattenSystemAssignedToModel(input *SystemAssigned) []ModelSystemAssigned {
 	if input == nil {
 		return []ModelSystemAssigned{}
 	}

--- a/resourcemanager/identity/system_or_user_assigned_list.go
+++ b/resourcemanager/identity/system_or_user_assigned_list.go
@@ -108,7 +108,7 @@ func ExpandSystemOrUserAssignedListFromModel(input []ModelSystemAssignedUserAssi
 	if len(input) == 0 {
 		return &SystemOrUserAssignedList{
 			Type:        TypeNone,
-			IdentityIds: []string{},
+			IdentityIds: nil,
 		}, nil
 	}
 

--- a/resourcemanager/identity/system_or_user_assigned_list.go
+++ b/resourcemanager/identity/system_or_user_assigned_list.go
@@ -124,8 +124,8 @@ func ExpandSystemOrUserAssignedListFromModel(input []ModelSystemAssignedUserAssi
 	}, nil
 }
 
-// FlattenSystemAssignedOrUserAssignedListFromModel turns a SystemOrUserAssignedList into a typed schema model
-func FlattenSystemAssignedOrUserAssignedListFromModel(input *SystemOrUserAssignedList) (*[]ModelSystemAssignedUserAssigned, error) {
+// FlattenSystemAssignedOrUserAssignedListToModel turns a SystemOrUserAssignedList into a typed schema model
+func FlattenSystemAssignedOrUserAssignedListToModel(input *SystemOrUserAssignedList) (*[]ModelSystemAssignedUserAssigned, error) {
 	if input == nil {
 		return &[]ModelSystemAssignedUserAssigned{}, nil
 	}

--- a/resourcemanager/identity/system_or_user_assigned_list.go
+++ b/resourcemanager/identity/system_or_user_assigned_list.go
@@ -102,3 +102,54 @@ func FlattenSystemAssignedOrUserAssignedList(input *SystemOrUserAssignedList) (*
 		},
 	}, nil
 }
+
+// ExpandSystemOrUserAssignedListFromModel expands the typed schema input into a SystemOrUserAssignedList struct
+func ExpandSystemOrUserAssignedListFromModel(input []ModelSystemAssignedUserAssigned) (*SystemOrUserAssignedList, error) {
+	if len(input) == 0 {
+		return &SystemOrUserAssignedList{
+			Type:        TypeNone,
+			IdentityIds: []string{},
+		}, nil
+	}
+
+	identity := input[0]
+
+	if len(identity.IdentityIds) > 0 && identity.Type != TypeUserAssigned {
+		return nil, fmt.Errorf("`identity_ids` can only be specified when `type` is set to %q", TypeUserAssigned)
+	}
+
+	return &SystemOrUserAssignedList{
+		Type:        identity.Type,
+		IdentityIds: identity.IdentityIds,
+	}, nil
+}
+
+// FlattenSystemAssignedOrUserAssignedListFromModel turns a SystemOrUserAssignedList into a typed schema model
+func FlattenSystemAssignedOrUserAssignedListFromModel(input *SystemOrUserAssignedList) (*[]ModelSystemAssignedUserAssigned, error) {
+	if input == nil {
+		return &[]ModelSystemAssignedUserAssigned{}, nil
+	}
+
+	input.Type = normalizeType(input.Type)
+	if input.Type != TypeSystemAssigned && input.Type != TypeUserAssigned {
+		return &[]ModelSystemAssignedUserAssigned{}, nil
+	}
+
+	identityIds := make([]string, 0)
+	for _, raw := range input.IdentityIds {
+		id, err := commonids.ParseUserAssignedIdentityIDInsensitively(raw)
+		if err != nil {
+			return nil, fmt.Errorf("parsing %q as a User Assigned Identity ID: %+v", raw, err)
+		}
+		identityIds = append(identityIds, id.ID())
+	}
+
+	return &[]ModelSystemAssignedUserAssigned{
+		{
+			Type:        input.Type,
+			IdentityIds: identityIds,
+			PrincipalId: input.PrincipalId,
+			TenantId:    input.TenantId,
+		},
+	}, nil
+}

--- a/resourcemanager/identity/system_or_user_assigned_map.go
+++ b/resourcemanager/identity/system_or_user_assigned_map.go
@@ -132,8 +132,8 @@ func ExpandSystemOrUserAssignedMapFromModel(input []ModelSystemAssignedUserAssig
 	}, nil
 }
 
-// FlattenSystemOrUserAssignedMapFromModel turns a SystemOrUserAssignedMap into a typed schema model
-func FlattenSystemOrUserAssignedMapFromModel(input *SystemOrUserAssignedMap) (*[]ModelSystemAssignedUserAssigned, error) {
+// FlattenSystemOrUserAssignedMapToModel turns a SystemOrUserAssignedMap into a typed schema model
+func FlattenSystemOrUserAssignedMapToModel(input *SystemOrUserAssignedMap) (*[]ModelSystemAssignedUserAssigned, error) {
 	if input == nil {
 		return &[]ModelSystemAssignedUserAssigned{}, nil
 	}

--- a/resourcemanager/identity/system_or_user_assigned_map.go
+++ b/resourcemanager/identity/system_or_user_assigned_map.go
@@ -110,7 +110,7 @@ func ExpandSystemOrUserAssignedMapFromModel(input []ModelSystemAssignedUserAssig
 	if len(input) == 0 {
 		return &SystemOrUserAssignedMap{
 			Type:        TypeNone,
-			IdentityIds: map[string]UserAssignedIdentityDetails{},
+			IdentityIds: nil,
 		}, nil
 	}
 

--- a/resourcemanager/identity/system_or_user_assigned_map.go
+++ b/resourcemanager/identity/system_or_user_assigned_map.go
@@ -104,3 +104,60 @@ func FlattenSystemOrUserAssignedMap(input *SystemOrUserAssignedMap) (*[]interfac
 		},
 	}, nil
 }
+
+// ExpandSystemOrUserAssignedMapFromModel expands the typed schema input into a SystemOrUserAssignedMap struct
+func ExpandSystemOrUserAssignedMapFromModel(input []ModelSystemAssignedUserAssigned) (*SystemOrUserAssignedMap, error) {
+	if len(input) == 0 {
+		return &SystemOrUserAssignedMap{
+			Type:        TypeNone,
+			IdentityIds: map[string]UserAssignedIdentityDetails{},
+		}, nil
+	}
+
+	identity := input[0]
+
+	identityIds := make(map[string]UserAssignedIdentityDetails, len(identity.IdentityIds))
+	for _, v := range identity.IdentityIds {
+		identityIds[v] = UserAssignedIdentityDetails{
+			// intentionally empty since the expand shouldn't send these values
+		}
+	}
+	if len(identityIds) > 0 && identity.Type != TypeUserAssigned {
+		return nil, fmt.Errorf("`identity_ids` can only be specified when `type` is set to %q", TypeUserAssigned)
+	}
+
+	return &SystemOrUserAssignedMap{
+		Type:        identity.Type,
+		IdentityIds: identityIds,
+	}, nil
+}
+
+// FlattenSystemOrUserAssignedMapFromModel turns a SystemOrUserAssignedMap into a typed schema model
+func FlattenSystemOrUserAssignedMapFromModel(input *SystemOrUserAssignedMap) (*[]ModelSystemAssignedUserAssigned, error) {
+	if input == nil {
+		return &[]ModelSystemAssignedUserAssigned{}, nil
+	}
+
+	input.Type = normalizeType(input.Type)
+	if input.Type != TypeSystemAssigned && input.Type != TypeUserAssigned {
+		return &[]ModelSystemAssignedUserAssigned{}, nil
+	}
+
+	identityIds := make([]string, 0)
+	for raw := range input.IdentityIds {
+		id, err := commonids.ParseUserAssignedIdentityIDInsensitively(raw)
+		if err != nil {
+			return nil, fmt.Errorf("parsing %q as a User Assigned Identity ID: %+v", raw, err)
+		}
+		identityIds = append(identityIds, id.ID())
+	}
+
+	return &[]ModelSystemAssignedUserAssigned{
+		{
+			Type:        input.Type,
+			IdentityIds: identityIds,
+			PrincipalId: input.PrincipalId,
+			TenantId:    input.TenantId,
+		},
+	}, nil
+}

--- a/resourcemanager/identity/tfschema_model.go
+++ b/resourcemanager/identity/tfschema_model.go
@@ -1,0 +1,19 @@
+package identity
+
+type ModelUserAssigned struct {
+	Type        Type     `tfschema:"type"`
+	IdentityIds []string `tfschema:"identity_ids"`
+}
+
+type ModelSystemAssigned struct {
+	Type        Type   `tfschema:"type"`
+	PrincipalId string `tfschema:"principal_id"`
+	TenantId    string `tfschema:"tenant_id"`
+}
+
+type ModelSystemAssignedUserAssigned struct {
+	Type        Type     `tfschema:"type"`
+	PrincipalId string   `tfschema:"principal_id"`
+	TenantId    string   `tfschema:"tenant_id"`
+	IdentityIds []string `tfschema:"identity_ids"`
+}

--- a/resourcemanager/identity/user_assigned_list.go
+++ b/resourcemanager/identity/user_assigned_list.go
@@ -96,7 +96,7 @@ func ExpandUserAssignedListFromModel(input []ModelUserAssigned) (*UserAssignedLi
 	if len(input) == 0 {
 		return &UserAssignedList{
 			Type:        TypeNone,
-			IdentityIds: []string{},
+			IdentityIds: nil,
 		}, nil
 	}
 

--- a/resourcemanager/identity/user_assigned_list.go
+++ b/resourcemanager/identity/user_assigned_list.go
@@ -90,3 +90,48 @@ func FlattenUserAssignedList(input *UserAssignedList) (*[]interface{}, error) {
 		},
 	}, nil
 }
+
+// ExpandUserAssignedListFromModel expands the typed schema input into a UserAssignedList struct
+func ExpandUserAssignedListFromModel(input []ModelUserAssigned) (*UserAssignedList, error) {
+	if len(input) == 0 {
+		return &UserAssignedList{
+			Type:        TypeNone,
+			IdentityIds: []string{},
+		}, nil
+	}
+
+	identity := input[0]
+	return &UserAssignedList{
+		Type:        identity.Type,
+		IdentityIds: identity.IdentityIds,
+	}, nil
+}
+
+// FlattenUserAssignedListFromModel turns a UserAssignedList into a typed schema model
+func FlattenUserAssignedListFromModel(input *UserAssignedList) (*[]ModelUserAssigned, error) {
+	if input == nil {
+		return &[]ModelUserAssigned{}, nil
+	}
+
+	input.Type = normalizeType(input.Type)
+
+	if input.Type != TypeUserAssigned {
+		return &[]ModelUserAssigned{}, nil
+	}
+
+	identityIds := make([]string, 0)
+	for _, raw := range input.IdentityIds {
+		id, err := commonids.ParseUserAssignedIdentityIDInsensitively(raw)
+		if err != nil {
+			return nil, fmt.Errorf("parsing %q as a User Assigned Identity ID: %+v", raw, err)
+		}
+		identityIds = append(identityIds, id.ID())
+	}
+
+	return &[]ModelUserAssigned{
+		{
+			Type:        input.Type,
+			IdentityIds: identityIds,
+		},
+	}, nil
+}

--- a/resourcemanager/identity/user_assigned_list.go
+++ b/resourcemanager/identity/user_assigned_list.go
@@ -107,8 +107,8 @@ func ExpandUserAssignedListFromModel(input []ModelUserAssigned) (*UserAssignedLi
 	}, nil
 }
 
-// FlattenUserAssignedListFromModel turns a UserAssignedList into a typed schema model
-func FlattenUserAssignedListFromModel(input *UserAssignedList) (*[]ModelUserAssigned, error) {
+// FlattenUserAssignedListToModel turns a UserAssignedList into a typed schema model
+func FlattenUserAssignedListToModel(input *UserAssignedList) (*[]ModelUserAssigned, error) {
 	if input == nil {
 		return &[]ModelUserAssigned{}, nil
 	}

--- a/resourcemanager/identity/user_assigned_map.go
+++ b/resourcemanager/identity/user_assigned_map.go
@@ -117,8 +117,8 @@ func ExpandUserAssignedMapFromModel(input []ModelUserAssigned) (*UserAssignedMap
 	}, nil
 }
 
-// FlattenUserAssignedMapFromModel turns a UserAssignedMap into a typed schema model
-func FlattenUserAssignedMapFromModel(input *UserAssignedMap) (*[]ModelUserAssigned, error) {
+// FlattenUserAssignedMapToModel turns a UserAssignedMap into a typed schema model
+func FlattenUserAssignedMapToModel(input *UserAssignedMap) (*[]ModelUserAssigned, error) {
 	if input == nil {
 		return &[]ModelUserAssigned{}, nil
 	}

--- a/resourcemanager/identity/user_assigned_map.go
+++ b/resourcemanager/identity/user_assigned_map.go
@@ -98,7 +98,7 @@ func ExpandUserAssignedMapFromModel(input []ModelUserAssigned) (*UserAssignedMap
 	if len(input) == 0 {
 		return &UserAssignedMap{
 			Type:        TypeNone,
-			IdentityIds: map[string]UserAssignedIdentityDetails{},
+			IdentityIds: nil,
 		}, nil
 	}
 

--- a/resourcemanager/identity/user_assigned_map.go
+++ b/resourcemanager/identity/user_assigned_map.go
@@ -92,3 +92,56 @@ func FlattenUserAssignedMap(input *UserAssignedMap) (*[]interface{}, error) {
 		},
 	}, nil
 }
+
+// ExpandUserAssignedMapFromModel expands the typed schema input into a UserAssignedMap struct
+func ExpandUserAssignedMapFromModel(input []ModelUserAssigned) (*UserAssignedMap, error) {
+	if len(input) == 0 {
+		return &UserAssignedMap{
+			Type:        TypeNone,
+			IdentityIds: map[string]UserAssignedIdentityDetails{},
+		}, nil
+	}
+
+	identity := input[0]
+
+	identityIds := make(map[string]UserAssignedIdentityDetails, 0)
+	for _, v := range identity.IdentityIds {
+		identityIds[v] = UserAssignedIdentityDetails{
+			// intentionally empty since the expand shouldn't send these values
+		}
+	}
+
+	return &UserAssignedMap{
+		Type:        identity.Type,
+		IdentityIds: identityIds,
+	}, nil
+}
+
+// FlattenUserAssignedMapFromModel turns a UserAssignedMap into a typed schema model
+func FlattenUserAssignedMapFromModel(input *UserAssignedMap) (*[]ModelUserAssigned, error) {
+	if input == nil {
+		return &[]ModelUserAssigned{}, nil
+	}
+
+	input.Type = normalizeType(input.Type)
+
+	if input.Type != TypeUserAssigned {
+		return &[]ModelUserAssigned{}, nil
+	}
+
+	identityIds := make([]string, 0)
+	for raw := range input.IdentityIds {
+		id, err := commonids.ParseUserAssignedIdentityIDInsensitively(raw)
+		if err != nil {
+			return nil, fmt.Errorf("parsing %q as a User Assigned Identity ID: %+v", raw, err)
+		}
+		identityIds = append(identityIds, id.ID())
+	}
+
+	return &[]ModelUserAssigned{
+		{
+			Type:        input.Type,
+			IdentityIds: identityIds,
+		},
+	}, nil
+}


### PR DESCRIPTION
The identity package currently has support for expanding/flattening from/to the raw representation of identity (i.e. `[]interface{}`), to/from the SDK types (e.g. `SystemAndUserAssignedList`). This works fine for the untyped flavor code. However, it lacks of supports for the code using typed SDK.

This PR defines models to be used for the typed SDK:

- `ModelUserAssinged`: for user assigned identity (either the user assigned identity in the SDK definition is a list or a map)
- `ModeSystemAssigned`: for system assigned identity
- `ModeSystemAssignedUserAssigned`: for system and/or user assigned identity, it doesn't matter whether it is "or" or "and" for the schema model (thought it matters when choosing the correct schema and the correct expand/flatten function).

Arguably, the `tfschema` tags can be removed for the SDK types, as they are not expected to be used as part of the schema model, instead they represents the SDK type. But if we directly remove them, it will affect the current provider code for following files:

- internal/services/mssql/mssql_managed_instance_resource.go
- internal/services/mssql/mssql_managed_instance_data_source.go

Once this PR got merged, we can do a follow up PR to change these files to using the typed model, and remove the `tfschema` tags for the SDK types.

