### PR TITLE
Auth: CLI method mitigate breaking change introduced in CLI v2.37.0

### DIFF
--- a/authentication/auth_method_azure_cli_token_multi_tenant.go
+++ b/authentication/auth_method_azure_cli_token_multi_tenant.go
@@ -18,6 +18,11 @@ type azureCliTokenMultiTenantAuth struct {
 }
 
 func (a azureCliTokenMultiTenantAuth) build(b Builder) (authMethod, error) {
+	ver, err := populateAzVersion(false)
+	if err != nil {
+		return nil, err
+	}
+
 	auth := azureCliTokenMultiTenantAuth{
 		clientId: "04b07795-8ddb-461a-bbee-02f9e1bf7b46", // fixed first party client id for Az CLI
 		profile: &azureCLIProfileMultiTenant{
@@ -25,9 +30,11 @@ func (a azureCliTokenMultiTenantAuth) build(b Builder) (authMethod, error) {
 			subscriptionId:     b.SubscriptionID,
 			tenantId:           b.TenantID,
 			auxiliaryTenantIDs: b.AuxiliaryTenantIDs,
+			azVersion:          *ver,
 		},
 		servicePrincipalAuthDocsLink: b.ClientSecretDocsLink,
 	}
+
 	profilePath, err := cli.ProfilePath()
 	if err != nil {
 		return nil, fmt.Errorf("loading the Profile Path from the Azure CLI: %+v", err)
@@ -146,7 +153,7 @@ func (a azureCliTokenMultiTenantAuth) populateConfig(c *Config) error {
 	c.SubscriptionID = a.profile.subscriptionId
 
 	c.GetAuthenticatedObjectID = func(ctx context.Context) (*string, error) {
-		objectId, err := obtainAuthenticatedObjectID()
+		objectId, err := obtainAuthenticatedObjectID(a.profile.azVersion)
 		if err != nil {
 			return nil, err
 		}

--- a/authentication/azure_cli_profile_multi_tenant.go
+++ b/authentication/azure_cli_profile_multi_tenant.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/Azure/go-autorest/autorest/azure/cli"
+	"github.com/hashicorp/go-version"
 )
 
 type azureCLIProfileMultiTenant struct {
@@ -13,12 +14,23 @@ type azureCLIProfileMultiTenant struct {
 	subscriptionId     string
 	tenantId           string
 	auxiliaryTenantIDs []string
+
+	azVersion version.Version
 }
 
 func (a *azureCLIProfileMultiTenant) populateFields() error {
-	// ensure we know the Subscription ID - since it's needed for everything else
+	// Ensure we know the Subscription ID - since it's needed for everything else
 	if a.subscriptionId == "" {
 		err := a.populateSubscriptionID()
+		if err != nil {
+			return err
+		}
+	}
+
+	// Ensure we know the Tenant ID - since it's needed for everything else
+	// Note that order matters that subscription id should be populated first, and then tenant id.
+	if a.tenantId == "" {
+		err := a.populateTenantID()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Since v2.37.0, CLI migrates to using MS graph for the AD related apis,
this causes breaking change on the resulting data model, which includes
feild `object_id` being renamed to `id`. This causes CLI auth method
failed to work for CLI since v2.37.0.

This commit checks the CLI version and read the corresponding field for
object id differently, for both CLI and multi tenant CLI auth methods.

Besides, the multi tenant CLI auth method seems to be broken even prior
to v2.37.0, when there is nothing configured in the provider block. This
commit also fixed that part by populating the tenant id and subscription
id in case they are empty.

Fix #118