### PR TITLE
Generic implementation for the `pointer`/`tfdata` `ToXXX()` and `FromXXX()` utilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,4 +50,4 @@ require (
 	google.golang.org/protobuf v1.26.0 // indirect
 )
 
-go 1.17
+go 1.18

--- a/lang/pointer/from.go
+++ b/lang/pointer/from.go
@@ -39,3 +39,8 @@ func FromSliceOfStrings(input []string) *[]string {
 func FromString(input string) *string {
 	return &input
 }
+
+// From turns an object into a pointer to it.
+func From[T any](input T) *T {
+	return &input
+}

--- a/lang/pointer/to.go
+++ b/lang/pointer/to.go
@@ -74,3 +74,32 @@ func ToString(input *string) string {
 
 	return ""
 }
+
+type primary interface {
+	~bool | ~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~float32 | ~float64 | ~string
+}
+
+// ToPrimary turns a pointer to a primary into a primary, returning its zero value if it's nul
+func ToPrimary[T primary](input *T) T {
+	if input != nil {
+		return *input
+	}
+	var v T
+	return v
+}
+
+// ToMap turns a pointer to a map into a map, returning its zero value if it's nul
+func ToMap[K primary, T primary | interface{}](input *map[K]T) map[K]T {
+	if input != nil {
+		return *input
+	}
+	return map[K]T{}
+}
+
+// ToSlice turns a pointer to a slice into a slice, returning its zero value if it's nul
+func FromSlice[T primary | interface{}](input *[]T) []T {
+	if input != nil {
+		return *input
+	}
+	return []T{}
+}

--- a/lang/pointer/to.go
+++ b/lang/pointer/to.go
@@ -1,5 +1,7 @@
 package pointer
 
+import "github.com/hashicorp/go-azure-helpers/lang/types"
+
 // ToBool turns a pointer to a bool into a bool, returning the default value for a bool if it's nil
 func ToBool(input *bool) bool {
 	if input != nil {
@@ -75,12 +77,8 @@ func ToString(input *string) string {
 	return ""
 }
 
-type primary interface {
-	~bool | ~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~float32 | ~float64 | ~string
-}
-
 // ToPrimary turns a pointer to a primary into a primary, returning its zero value if it's nul
-func ToPrimary[T primary](input *T) T {
+func ToPrimary[T types.Primary](input *T) T {
 	if input != nil {
 		return *input
 	}
@@ -89,7 +87,7 @@ func ToPrimary[T primary](input *T) T {
 }
 
 // ToMap turns a pointer to a map into a map, returning its zero value if it's nul
-func ToMap[K primary, T primary | interface{}](input *map[K]T) map[K]T {
+func ToMap[K types.Primary, T types.Primary | interface{}](input *map[K]T) map[K]T {
 	if input != nil {
 		return *input
 	}
@@ -97,7 +95,7 @@ func ToMap[K primary, T primary | interface{}](input *map[K]T) map[K]T {
 }
 
 // ToSlice turns a pointer to a slice into a slice, returning its zero value if it's nul
-func FromSlice[T primary | interface{}](input *[]T) []T {
+func FromSlice[T types.Primary | interface{}](input *[]T) []T {
 	if input != nil {
 		return *input
 	}

--- a/lang/pointer/to.go
+++ b/lang/pointer/to.go
@@ -95,7 +95,7 @@ func ToMap[K types.Primary, T types.Primary | interface{}](input *map[K]T) map[K
 }
 
 // ToSlice turns a pointer to a slice into a slice, returning its zero value if it's nul
-func FromSlice[T types.Primary | interface{}](input *[]T) []T {
+func ToSlice[T types.Primary | interface{}](input *[]T) []T {
 	if input != nil {
 		return *input
 	}

--- a/lang/tfdata/from.go
+++ b/lang/tfdata/from.go
@@ -1,0 +1,59 @@
+package tfdata
+
+import (
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/lang/types"
+)
+
+func FromSlice[T types.Primary](input *[]T) []interface{} {
+	result := make([]interface{}, 0)
+	if input != nil {
+		for _, item := range *input {
+			result = append(result, item)
+		}
+	}
+	return result
+}
+
+func FromRangeSlice[T types.Primary](input *[][]T) [][]interface{} {
+	result := make([][]interface{}, 0)
+	if input != nil {
+		for _, item := range *input {
+			result = append(result, FromSlice(&item))
+		}
+	}
+	return result
+}
+
+func FromMapOfPtr[K types.Primary, V types.Primary](input map[K]*V) map[K]interface{} {
+	result := make(map[K]interface{})
+	for k, v := range input {
+		if v == nil {
+			var value V
+			result[k] = value
+		} else {
+			result[k] = *v
+		}
+	}
+	return result
+}
+
+func FromMap[K types.Primary, V types.Primary](input map[K]V) map[K]interface{} {
+	result := make(map[K]interface{})
+	for k, v := range input {
+		result[k] = v
+	}
+	return result
+}
+
+func FromStringWithDelimiter(input *string, delimiter string) []interface{} {
+	result := make([]interface{}, 0)
+	if input != nil {
+		inputStrings := strings.Split(*input, delimiter)
+		for _, item := range inputStrings {
+			result = append(result, item)
+		}
+	}
+	return result
+}

--- a/lang/tfdata/to.go
+++ b/lang/tfdata/to.go
@@ -1,0 +1,68 @@
+package tfdata
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/types"
+)
+
+func ToSlice[T types.Primary](input []interface{}) *[]T {
+	result := make([]T, 0)
+	for _, item := range input {
+		if item != nil {
+			result = append(result, item.(T))
+		} else {
+			var v T
+			result = append(result, v)
+		}
+	}
+	return &result
+}
+
+func ToRangeSlice[T types.Primary](input []interface{}) *[][]T {
+	result := make([][]T, 0)
+	for _, item := range input {
+		if item != nil {
+			result = append(result, *ToSlice[T](item.([]interface{})))
+		}
+	}
+	return &result
+}
+
+func ToMap[K types.Primary, V types.Primary](input map[K]interface{}) map[K]V {
+	result := make(map[K]V)
+	for k, v := range input {
+		result[k] = v.(V)
+	}
+	return result
+}
+
+func ToMapOfPtr[K types.Primary, V types.Primary](input map[K]interface{}) map[K]*V {
+	result := make(map[K]*V)
+	for k, v := range input {
+		result[k] = pointer.From(v.(V))
+	}
+	return result
+}
+
+func ToStringWithDelimiter(input []interface{}, delimiter string) *string {
+	result := make([]string, 0)
+	for _, item := range input {
+		if item != nil {
+			switch item.(type) {
+			case string:
+				result = append(result, item.(string))
+			case int:
+				result = append(result, strconv.Itoa(item.(int)))
+			default:
+				// TODO: should we handle other types?
+				result = append(result, "")
+			}
+		} else {
+			result = append(result, "")
+		}
+	}
+	return pointer.FromString(strings.Join(result, delimiter))
+}

--- a/lang/types/types.go
+++ b/lang/types/types.go
@@ -1,0 +1,5 @@
+package types
+
+type Primary interface {
+	~bool | ~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~float32 | ~float64 | ~string
+}


### PR DESCRIPTION
For `pointer` package, rewrite the existing functions via generics.

Adding a new package `tfdata` to rewrite the same thing from https://github.com/hashicorp/terraform-provider-azurerm/blob/main/utils/common_marshal.go, using generics (except one for the delimiter string, which is not needed to be generics).