### PR TITLE
lang/response: making WasNotFound public

### DIFF
--- a/lang/response/response.go
+++ b/lang/response/response.go
@@ -6,20 +6,22 @@ import (
 
 // WasBadRequest returns true if the HttpResponse is non-nil and has a status code of BadRequest
 func WasBadRequest(resp *http.Response) bool {
-	return responseWasStatusCode(resp, http.StatusBadRequest)
+	return WasStatusCode(resp, http.StatusBadRequest)
 }
 
 // WasConflict returns true if the HttpResponse is non-nil and has a status code of Conflict
 func WasConflict(resp *http.Response) bool {
-	return responseWasStatusCode(resp, http.StatusConflict)
+	return WasStatusCode(resp, http.StatusConflict)
 }
 
 // WasNotFound returns true if the HttpResponse is non-nil and has a status code of NotFound
 func WasNotFound(resp *http.Response) bool {
-	return responseWasStatusCode(resp, http.StatusNotFound)
+	return WasStatusCode(resp, http.StatusNotFound)
 }
 
-func responseWasStatusCode(resp *http.Response, statusCode int) bool {
+// WasStatusCode returns true if the HttpResponse is non-nil and matches the Status Code
+// It's recommended to use WasBadRequest/WasConflict/WasNotFound where possible instead
+func WasStatusCode(resp *http.Response, statusCode int) bool {
 	if r := resp; r != nil {
 		if r.StatusCode == statusCode {
 			return true


### PR DESCRIPTION
This allows custom status codes to be checked as required to workaround Swagger/API issues whilst also handling the response being nil due to a dropped connection or similar.