### PR TITLE
Support a default environment from metadata

### DIFF
--- a/authentication/environment.go
+++ b/authentication/environment.go
@@ -113,7 +113,7 @@ func AzureEnvironmentByNameFromEndpoint(ctx context.Context, endpoint string, en
 
 	// while the array contains values
 	for _, env := range environments {
-		if strings.EqualFold(env.Name, environmentName) {
+		if strings.EqualFold(env.Name, environmentName) || (environmentName == "" && len(environments) == 1) {
 			// if resourceManager endpoint is empty, assume it's the provided endpoint
 			if env.ResourceManager == "" {
 				env.ResourceManager = fmt.Sprintf("https://%s/", endpoint)


### PR DESCRIPTION
Support a default environment when a single env is returned from the metadata service, and no environment name was specified