### PR TITLE
CLI auth: refresh account list prior to getting subscription id during build

### DIFF
--- a/authentication/auth_method_azure_cli_token.go
+++ b/authentication/auth_method_azure_cli_token.go
@@ -50,6 +50,10 @@ func (a azureCliTokenAuth) build(b Builder) (authMethod, error) {
 		servicePrincipalAuthDocsLink: b.ClientSecretDocsLink,
 	}
 
+	if err := refreshAccounts(); err != nil {
+		return nil, fmt.Errorf("refreshing the account list from the Azure CLI: %v", err)
+	}
+
 	var acc *cli.Subscription
 	if auth.profile.tenantOnly {
 		var err error
@@ -283,6 +287,17 @@ func obtainAuthorizationToken(endpoint string, subscriptionId string, tenantId s
 	}
 
 	return &token, nil
+}
+
+func refreshAccounts() error {
+	var accs []cli.Subscription
+	cmd := []string{"account", "list", "--refresh"}
+	err := jsonUnmarshalAzCmd(&accs, cmd...)
+	if err != nil {
+		return fmt.Errorf("parsing json result from the Azure CLI: %v", err)
+	}
+
+	return nil
 }
 
 // obtainSubscription returns a Subscription object of the specified subscriptionId.

--- a/authentication/auth_method_azure_cli_token_multi_tenant.go
+++ b/authentication/auth_method_azure_cli_token_multi_tenant.go
@@ -35,6 +35,10 @@ func (a azureCliTokenMultiTenantAuth) build(b Builder) (authMethod, error) {
 		servicePrincipalAuthDocsLink: b.ClientSecretDocsLink,
 	}
 
+	if err := refreshAccounts(); err != nil {
+		return nil, fmt.Errorf("refreshing the account list from the Azure CLI: %v", err)
+	}
+
 	profilePath, err := cli.ProfilePath()
 	if err != nil {
 		return nil, fmt.Errorf("loading the Profile Path from the Azure CLI: %+v", err)


### PR DESCRIPTION
Refresh account list prior to getting subscription id during building the auth.

Related to https://github.com/hashicorp/terraform-provider-azurerm/issues/17979