### PR TITLE
Add ability to specify path to OIDC token

### DIFF
--- a/authentication/auth_method_oidc.go
+++ b/authentication/auth_method_oidc.go
@@ -3,6 +3,7 @@ package authentication
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/hashicorp/go-multierror"
@@ -16,6 +17,7 @@ type oidcAuth struct {
 	clientId            string
 	environment         string
 	idToken             string
+	idTokenPath         string
 	idTokenRequestToken string
 	idTokenRequestUrl   string
 	tenantId            string
@@ -27,6 +29,7 @@ func (a oidcAuth) build(b Builder) (authMethod, error) {
 		clientId:            b.ClientID,
 		environment:         b.Environment,
 		idToken:             b.IDToken,
+		idTokenPath:         b.IDTokenPath,
 		idTokenRequestUrl:   b.IDTokenRequestURL,
 		idTokenRequestToken: b.IDTokenRequestToken,
 		tenantId:            b.TenantID,
@@ -35,7 +38,7 @@ func (a oidcAuth) build(b Builder) (authMethod, error) {
 }
 
 func (a oidcAuth) isApplicable(b Builder) bool {
-	return b.SupportsOIDCAuth && b.UseMicrosoftGraph && (b.IDToken != "" || (b.IDTokenRequestURL != "" && b.IDTokenRequestToken != ""))
+	return b.SupportsOIDCAuth && b.UseMicrosoftGraph && (b.IDToken != "" || b.IDTokenPath != "" || (b.IDTokenRequestURL != "" && b.IDTokenRequestToken != ""))
 }
 
 func (a oidcAuth) name() string {
@@ -52,7 +55,7 @@ func (a oidcAuth) getMSALToken(ctx context.Context, api environments.Api, _ auto
 		return nil, fmt.Errorf("environment config error: %v", err)
 	}
 
-	if a.idToken == "" {
+	if a.idToken == "" && a.idTokenPath == "" {
 		conf := auth.GitHubOIDCConfig{
 			Environment:         environment,
 			TenantID:            a.tenantId,
@@ -65,17 +68,37 @@ func (a oidcAuth) getMSALToken(ctx context.Context, api environments.Api, _ auto
 		return &authWrapper.Authorizer{Authorizer: conf.TokenSource(ctx)}, nil
 	}
 
+	idToken := a.idToken
+
+	if a.idTokenPath != "" {
+		idToken, err = a.readTokenFile(a.idTokenPath)
+
+		if err != nil {
+			return nil, fmt.Errorf("reading token file: %v", err)
+		}
+	}
+
 	conf := auth.ClientCredentialsConfig{
 		Environment:        environment,
 		TenantID:           a.tenantId,
 		AuxiliaryTenantIDs: a.auxiliaryTenantIds,
 		ClientID:           a.clientId,
-		FederatedAssertion: a.idToken,
+		FederatedAssertion: idToken,
 		Scopes:             []string{api.DefaultScope()},
 		TokenVersion:       auth.TokenVersion2,
 	}
 
 	return &authWrapper.Authorizer{Authorizer: conf.TokenSource(ctx, auth.ClientCredentialsAssertionType)}, nil
+}
+
+func (a oidcAuth) readTokenFile(f string) (string, error) {
+	idTokenData, err := ioutil.ReadFile(f)
+
+	if err != nil {
+		return "", fmt.Errorf("reading OIDC Token %q: %v", f, err)
+	}
+
+	return string(idTokenData), nil
 }
 
 func (a oidcAuth) populateConfig(c *Config) error {
@@ -98,12 +121,12 @@ func (a oidcAuth) validate() error {
 		err = multierror.Append(err, fmt.Errorf(fmtErrorMessage, "Client ID"))
 	}
 
-	if a.idTokenRequestUrl == "" && a.idToken == "" {
-		err = multierror.Append(err, fmt.Errorf(fmtErrorMessage, "ID Token or ID Token Request URL"))
+	if a.idTokenRequestUrl == "" && a.idToken == "" && a.idTokenPath == "" {
+		err = multierror.Append(err, fmt.Errorf(fmtErrorMessage, "ID Token or ID Token Path or ID Token Request URL"))
 	}
 
-	if a.idTokenRequestToken == "" && a.idToken == "" {
-		err = multierror.Append(err, fmt.Errorf(fmtErrorMessage, "ID Token or ID Token Request Token"))
+	if a.idTokenRequestToken == "" && a.idToken == "" && a.idTokenPath == "" {
+		err = multierror.Append(err, fmt.Errorf(fmtErrorMessage, "ID Token or ID Token Path or ID Token Request Token"))
 	}
 
 	return err.ErrorOrNil()

--- a/authentication/auth_method_oidc.go
+++ b/authentication/auth_method_oidc.go
@@ -78,7 +78,7 @@ func (a oidcAuth) getMSALToken(ctx context.Context, api environments.Api, _ auto
 		}
 
 		if a.idToken != "" && a.idToken != idToken {
-			return nil, fmt.Errorf("mismatch between supplied OIDC token and supplied OIDC token file")
+			return nil, fmt.Errorf("mismatch between supplied OIDC token and supplied OIDC token file contents - please either remove one or ensure they match")
 		}
 	}
 

--- a/authentication/auth_method_oidc.go
+++ b/authentication/auth_method_oidc.go
@@ -3,7 +3,7 @@ package authentication
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/hashicorp/go-multierror"
@@ -92,7 +92,7 @@ func (a oidcAuth) getMSALToken(ctx context.Context, api environments.Api, _ auto
 }
 
 func (a oidcAuth) readTokenFile(f string) (string, error) {
-	idTokenData, err := ioutil.ReadFile(f)
+	idTokenData, err := os.ReadFile(f)
 
 	if err != nil {
 		return "", fmt.Errorf("reading OIDC Token %q: %v", f, err)

--- a/authentication/auth_method_oidc.go
+++ b/authentication/auth_method_oidc.go
@@ -76,6 +76,10 @@ func (a oidcAuth) getMSALToken(ctx context.Context, api environments.Api, _ auto
 		if err != nil {
 			return nil, fmt.Errorf("reading token file: %v", err)
 		}
+
+		if a.idToken != "" && a.idToken != idToken {
+			return nil, fmt.Errorf("mismatch between supplied OIDC token and supplied OIDC token file")
+		}
 	}
 
 	conf := auth.ClientCredentialsConfig{

--- a/authentication/auth_method_oidc.go
+++ b/authentication/auth_method_oidc.go
@@ -17,7 +17,7 @@ type oidcAuth struct {
 	clientId            string
 	environment         string
 	idToken             string
-	idTokenPath         string
+	idTokenFilePath     string
 	idTokenRequestToken string
 	idTokenRequestUrl   string
 	tenantId            string
@@ -29,7 +29,7 @@ func (a oidcAuth) build(b Builder) (authMethod, error) {
 		clientId:            b.ClientID,
 		environment:         b.Environment,
 		idToken:             b.IDToken,
-		idTokenPath:         b.IDTokenPath,
+		idTokenFilePath:     b.IDTokenFilePath,
 		idTokenRequestUrl:   b.IDTokenRequestURL,
 		idTokenRequestToken: b.IDTokenRequestToken,
 		tenantId:            b.TenantID,
@@ -38,7 +38,7 @@ func (a oidcAuth) build(b Builder) (authMethod, error) {
 }
 
 func (a oidcAuth) isApplicable(b Builder) bool {
-	return b.SupportsOIDCAuth && b.UseMicrosoftGraph && (b.IDToken != "" || b.IDTokenPath != "" || (b.IDTokenRequestURL != "" && b.IDTokenRequestToken != ""))
+	return b.SupportsOIDCAuth && b.UseMicrosoftGraph && (b.IDToken != "" || b.IDTokenFilePath != "" || (b.IDTokenRequestURL != "" && b.IDTokenRequestToken != ""))
 }
 
 func (a oidcAuth) name() string {
@@ -55,7 +55,7 @@ func (a oidcAuth) getMSALToken(ctx context.Context, api environments.Api, _ auto
 		return nil, fmt.Errorf("environment config error: %v", err)
 	}
 
-	if a.idToken == "" && a.idTokenPath == "" {
+	if a.idToken == "" && a.idTokenFilePath == "" {
 		conf := auth.GitHubOIDCConfig{
 			Environment:         environment,
 			TenantID:            a.tenantId,
@@ -70,8 +70,8 @@ func (a oidcAuth) getMSALToken(ctx context.Context, api environments.Api, _ auto
 
 	idToken := a.idToken
 
-	if a.idTokenPath != "" {
-		idToken, err = a.readTokenFile(a.idTokenPath)
+	if a.idTokenFilePath != "" {
+		idToken, err = a.readTokenFile(a.idTokenFilePath)
 
 		if err != nil {
 			return nil, fmt.Errorf("reading token file: %v", err)
@@ -121,12 +121,12 @@ func (a oidcAuth) validate() error {
 		err = multierror.Append(err, fmt.Errorf(fmtErrorMessage, "Client ID"))
 	}
 
-	if a.idTokenRequestUrl == "" && a.idToken == "" && a.idTokenPath == "" {
-		err = multierror.Append(err, fmt.Errorf(fmtErrorMessage, "ID Token or ID Token Path or ID Token Request URL"))
+	if a.idTokenRequestUrl == "" && a.idToken == "" && a.idTokenFilePath == "" {
+		err = multierror.Append(err, fmt.Errorf(fmtErrorMessage, "ID Token or ID Token File Path or ID Token Request URL"))
 	}
 
-	if a.idTokenRequestToken == "" && a.idToken == "" && a.idTokenPath == "" {
-		err = multierror.Append(err, fmt.Errorf(fmtErrorMessage, "ID Token or ID Token Path or ID Token Request Token"))
+	if a.idTokenRequestToken == "" && a.idToken == "" && a.idTokenFilePath == "" {
+		err = multierror.Append(err, fmt.Errorf(fmtErrorMessage, "ID Token or ID Token File Path or ID Token Request Token"))
 	}
 
 	return err.ErrorOrNil()

--- a/authentication/auth_method_oidc_test.go
+++ b/authentication/auth_method_oidc_test.go
@@ -70,10 +70,19 @@ func TestOIDC_isApplicable(t *testing.T) {
 			Valid: true,
 		},
 		{
-			Description: "Generic OIDC",
+			Description: "Generic OIDC with Token",
 			Builder: Builder{
 				SupportsOIDCAuth:  true,
 				IDToken:           "oidctoken",
+				UseMicrosoftGraph: true,
+			},
+			Valid: true,
+		},
+		{
+			Description: "Generic OIDC with Token Path",
+			Builder: Builder{
+				SupportsOIDCAuth:  true,
+				IDTokenPath:       "path/to/oidctoken",
 				UseMicrosoftGraph: true,
 			},
 			Valid: true,
@@ -123,12 +132,23 @@ func TestOIDC_validate(t *testing.T) {
 			ExpectError: false,
 		},
 		{
-			Description: "Valid Generic Configuration",
+			Description: "Valid Generic Configuration with Token",
 			Config: oidcAuth{
 				auxiliaryTenantIds: []string{"a-tenant-id", "b-tenant-id"},
 				clientId:           "client-id",
 				environment:        "environment",
 				idToken:            "oidctoken",
+				tenantId:           "tenant-id",
+			},
+			ExpectError: false,
+		},
+		{
+			Description: "Valid Generic Configuration with Token Path",
+			Config: oidcAuth{
+				auxiliaryTenantIds: []string{"a-tenant-id", "b-tenant-id"},
+				clientId:           "client-id",
+				environment:        "environment",
+				idTokenPath:        "path/to/oidctoken",
 				tenantId:           "tenant-id",
 			},
 			ExpectError: false,

--- a/authentication/auth_method_oidc_test.go
+++ b/authentication/auth_method_oidc_test.go
@@ -79,10 +79,10 @@ func TestOIDC_isApplicable(t *testing.T) {
 			Valid: true,
 		},
 		{
-			Description: "Generic OIDC with Token Path",
+			Description: "Generic OIDC with Token File Path",
 			Builder: Builder{
 				SupportsOIDCAuth:  true,
-				IDTokenPath:       "path/to/oidctoken",
+				IDTokenFilePath:   "path/to/oidctoken",
 				UseMicrosoftGraph: true,
 			},
 			Valid: true,
@@ -143,12 +143,12 @@ func TestOIDC_validate(t *testing.T) {
 			ExpectError: false,
 		},
 		{
-			Description: "Valid Generic Configuration with Token Path",
+			Description: "Valid Generic Configuration with Token File Path",
 			Config: oidcAuth{
 				auxiliaryTenantIds: []string{"a-tenant-id", "b-tenant-id"},
 				clientId:           "client-id",
 				environment:        "environment",
-				idTokenPath:        "path/to/oidctoken",
+				idTokenFilePath:    "path/to/oidctoken",
 				tenantId:           "tenant-id",
 			},
 			ExpectError: false,

--- a/authentication/builder.go
+++ b/authentication/builder.go
@@ -47,7 +47,7 @@ type Builder struct {
 	// OIDC Auth
 	SupportsOIDCAuth    bool
 	IDToken             string
-	IDTokenPath         string
+	IDTokenFilePath     string
 	IDTokenRequestURL   string
 	IDTokenRequestToken string
 

--- a/authentication/builder.go
+++ b/authentication/builder.go
@@ -47,6 +47,7 @@ type Builder struct {
 	// OIDC Auth
 	SupportsOIDCAuth    bool
 	IDToken             string
+	IDTokenPath         string
 	IDTokenRequestURL   string
 	IDTokenRequestToken string
 


### PR DESCRIPTION
Adds the ability to specify a path to an OIDC token in place of supplying the contents of the token.