### PR TITLE
refactor: resourceGroup -> resourceGroupName for consistency

### DIFF
--- a/resourcemanager/commonids/cloud_services_ip_configuration.go
+++ b/resourcemanager/commonids/cloud_services_ip_configuration.go
@@ -12,7 +12,7 @@ var _ resourceids.ResourceId = CloudServicesIPConfigurationId{}
 // CloudServicesIPConfigurationId is a struct representing the Resource ID for a Cloud Services I P Configuration
 type CloudServicesIPConfigurationId struct {
 	SubscriptionId       string
-	ResourceGroup        string
+	ResourceGroupName    string
 	CloudServiceName     string
 	RoleInstanceName     string
 	NetworkInterfaceName string
@@ -20,10 +20,10 @@ type CloudServicesIPConfigurationId struct {
 }
 
 // NewCloudServicesIPConfigurationID returns a new CloudServicesIPConfigurationId struct
-func NewCloudServicesIPConfigurationID(subscriptionId string, resourceGroup string, cloudServiceName string, roleInstanceName string, networkInterfaceName string, ipConfigurationName string) CloudServicesIPConfigurationId {
+func NewCloudServicesIPConfigurationID(subscriptionId string, resourceGroupName string, cloudServiceName string, roleInstanceName string, networkInterfaceName string, ipConfigurationName string) CloudServicesIPConfigurationId {
 	return CloudServicesIPConfigurationId{
 		SubscriptionId:       subscriptionId,
-		ResourceGroup:        resourceGroup,
+		ResourceGroupName:    resourceGroupName,
 		CloudServiceName:     cloudServiceName,
 		RoleInstanceName:     roleInstanceName,
 		NetworkInterfaceName: networkInterfaceName,
@@ -46,8 +46,8 @@ func ParseCloudServicesIPConfigurationID(input string) (*CloudServicesIPConfigur
 		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
 	}
 
-	if id.ResourceGroup, ok = parsed.Parsed["resourceGroup"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroup' was not found in the resource id %q", input)
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
 	}
 
 	if id.CloudServiceName, ok = parsed.Parsed["cloudServiceName"]; !ok {
@@ -85,8 +85,8 @@ func ParseCloudServicesIPConfigurationIDInsensitively(input string) (*CloudServi
 		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
 	}
 
-	if id.ResourceGroup, ok = parsed.Parsed["resourceGroup"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroup' was not found in the resource id %q", input)
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
 	}
 
 	if id.CloudServiceName, ok = parsed.Parsed["cloudServiceName"]; !ok {
@@ -126,7 +126,7 @@ func ValidateCloudServicesIPConfigurationID(input interface{}, key string) (warn
 // ID returns the formatted Cloud Services I P Configuration ID
 func (id CloudServicesIPConfigurationId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/cloudServices/%s/roleInstances/%s/networkInterfaces/%s/ipConfigurations/%s"
-	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.CloudServiceName, id.RoleInstanceName, id.NetworkInterfaceName, id.IpConfigurationName)
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.CloudServiceName, id.RoleInstanceName, id.NetworkInterfaceName, id.IpConfigurationName)
 }
 
 // Segments returns a slice of Resource ID Segments which comprise this Cloud Services I P Configuration ID
@@ -135,7 +135,7 @@ func (id CloudServicesIPConfigurationId) Segments() []resourceids.Segment {
 		resourceids.StaticSegment("subscriptions", "subscriptions", "subscriptions"),
 		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
 		resourceids.StaticSegment("resourceGroups", "resourceGroups", "resourceGroups"),
-		resourceids.ResourceGroupSegment("resourceGroup", "example-resource-group"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
 		resourceids.StaticSegment("providers", "providers", "providers"),
 		resourceids.ResourceProviderSegment("resourceProvider", "Microsoft.Compute", "Microsoft.Compute"),
 		resourceids.StaticSegment("cloudServices", "cloudServices", "cloudServices"),
@@ -153,7 +153,7 @@ func (id CloudServicesIPConfigurationId) Segments() []resourceids.Segment {
 func (id CloudServicesIPConfigurationId) String() string {
 	components := []string{
 		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
-		fmt.Sprintf("Resource Group: %q", id.ResourceGroup),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
 		fmt.Sprintf("Cloud Service Name: %q", id.CloudServiceName),
 		fmt.Sprintf("Role Instance Name: %q", id.RoleInstanceName),
 		fmt.Sprintf("Network Interface Name: %q", id.NetworkInterfaceName),

--- a/resourcemanager/commonids/cloud_services_ip_configuration_test.go
+++ b/resourcemanager/commonids/cloud_services_ip_configuration_test.go
@@ -15,8 +15,8 @@ func TestNewCloudServicesIPConfigurationID(t *testing.T) {
 		t.Fatalf("Expected %q but got %q for Segment 'SubscriptionId'", id.SubscriptionId, "12345678-1234-9876-4563-123456789012")
 	}
 
-	if id.ResourceGroup != "example-resource-group" {
-		t.Fatalf("Expected %q but got %q for Segment 'ResourceGroup'", id.ResourceGroup, "example-resource-group")
+	if id.ResourceGroupName != "example-resource-group" {
+		t.Fatalf("Expected %q but got %q for Segment 'ResourceGroup'", id.ResourceGroupName, "example-resource-group")
 	}
 
 	if id.CloudServiceName != "cloudServiceValue" {
@@ -125,7 +125,7 @@ func TestParseCloudServicesIPConfigurationID(t *testing.T) {
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Compute/cloudServices/cloudServiceValue/roleInstances/roleInstanceValue/networkInterfaces/networkInterfaceValue/ipConfigurations/ipConfigurationValue",
 			Expected: &CloudServicesIPConfigurationId{
 				SubscriptionId:       "12345678-1234-9876-4563-123456789012",
-				ResourceGroup:        "example-resource-group",
+				ResourceGroupName:    "example-resource-group",
 				CloudServiceName:     "cloudServiceValue",
 				RoleInstanceName:     "roleInstanceValue",
 				NetworkInterfaceName: "networkInterfaceValue",
@@ -157,8 +157,8 @@ func TestParseCloudServicesIPConfigurationID(t *testing.T) {
 			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
 		}
 
-		if actual.ResourceGroup != v.Expected.ResourceGroup {
-			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroupName, actual.ResourceGroupName)
 		}
 
 		if actual.CloudServiceName != v.Expected.CloudServiceName {
@@ -326,7 +326,7 @@ func TestParseCloudServicesIPConfigurationIDInsensitively(t *testing.T) {
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Compute/cloudServices/cloudServiceValue/roleInstances/roleInstanceValue/networkInterfaces/networkInterfaceValue/ipConfigurations/ipConfigurationValue",
 			Expected: &CloudServicesIPConfigurationId{
 				SubscriptionId:       "12345678-1234-9876-4563-123456789012",
-				ResourceGroup:        "example-resource-group",
+				ResourceGroupName:    "example-resource-group",
 				CloudServiceName:     "cloudServiceValue",
 				RoleInstanceName:     "roleInstanceValue",
 				NetworkInterfaceName: "networkInterfaceValue",
@@ -343,7 +343,7 @@ func TestParseCloudServicesIPConfigurationIDInsensitively(t *testing.T) {
 			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.cOmPuTe/cLoUdSeRvIcEs/cLoUdSeRvIcEvAlUe/rOlEiNsTaNcEs/rOlEiNsTaNcEvAlUe/nEtWoRkInTeRfAcEs/nEtWoRkInTeRfAcEvAlUe/iPcOnFiGuRaTiOnS/iPcOnFiGuRaTiOnVaLuE",
 			Expected: &CloudServicesIPConfigurationId{
 				SubscriptionId:       "12345678-1234-9876-4563-123456789012",
-				ResourceGroup:        "eXaMpLe-rEsOuRcE-GrOuP",
+				ResourceGroupName:    "eXaMpLe-rEsOuRcE-GrOuP",
 				CloudServiceName:     "cLoUdSeRvIcEvAlUe",
 				RoleInstanceName:     "rOlEiNsTaNcEvAlUe",
 				NetworkInterfaceName: "nEtWoRkInTeRfAcEvAlUe",
@@ -375,8 +375,8 @@ func TestParseCloudServicesIPConfigurationIDInsensitively(t *testing.T) {
 			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
 		}
 
-		if actual.ResourceGroup != v.Expected.ResourceGroup {
-			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
 		}
 
 		if actual.CloudServiceName != v.Expected.CloudServiceName {

--- a/resourcemanager/commonids/cloud_services_public_ip.go
+++ b/resourcemanager/commonids/cloud_services_public_ip.go
@@ -12,7 +12,7 @@ var _ resourceids.ResourceId = CloudServicesPublicIPAddressId{}
 // CloudServicesPublicIPAddressId is a struct representing the Resource ID for a Cloud Services Public I P Address
 type CloudServicesPublicIPAddressId struct {
 	SubscriptionId       string
-	ResourceGroup        string
+	ResourceGroupName    string
 	CloudServiceName     string
 	RoleInstanceName     string
 	NetworkInterfaceName string
@@ -21,10 +21,10 @@ type CloudServicesPublicIPAddressId struct {
 }
 
 // NewCloudServicesPublicIPAddressID returns a new CloudServicesPublicIPAddressId struct
-func NewCloudServicesPublicIPAddressID(subscriptionId string, resourceGroup string, cloudServiceName string, roleInstanceName string, networkInterfaceName string, ipConfigurationName string, publicIPAddressName string) CloudServicesPublicIPAddressId {
+func NewCloudServicesPublicIPAddressID(subscriptionId string, resourceGroupName string, cloudServiceName string, roleInstanceName string, networkInterfaceName string, ipConfigurationName string, publicIPAddressName string) CloudServicesPublicIPAddressId {
 	return CloudServicesPublicIPAddressId{
 		SubscriptionId:       subscriptionId,
-		ResourceGroup:        resourceGroup,
+		ResourceGroupName:    resourceGroupName,
 		CloudServiceName:     cloudServiceName,
 		RoleInstanceName:     roleInstanceName,
 		NetworkInterfaceName: networkInterfaceName,
@@ -48,8 +48,8 @@ func ParseCloudServicesPublicIPAddressID(input string) (*CloudServicesPublicIPAd
 		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
 	}
 
-	if id.ResourceGroup, ok = parsed.Parsed["resourceGroup"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroup' was not found in the resource id %q", input)
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
 	}
 
 	if id.CloudServiceName, ok = parsed.Parsed["cloudServiceName"]; !ok {
@@ -91,8 +91,8 @@ func ParseCloudServicesPublicIPAddressIDInsensitively(input string) (*CloudServi
 		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
 	}
 
-	if id.ResourceGroup, ok = parsed.Parsed["resourceGroup"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroup' was not found in the resource id %q", input)
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
 	}
 
 	if id.CloudServiceName, ok = parsed.Parsed["cloudServiceName"]; !ok {
@@ -133,10 +133,10 @@ func ValidateCloudServicesPublicIPAddressID(input interface{}, key string) (warn
 	return
 }
 
-// ID returns the formatted Cloud Services Public I P Address ID
+// ID returns the formatted Cloud Services Public IP Address ID
 func (id CloudServicesPublicIPAddressId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/cloudServices/%s/roleInstances/%s/networkInterfaces/%s/ipConfigurations/%s/publicIPAddresses/%s"
-	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.CloudServiceName, id.RoleInstanceName, id.NetworkInterfaceName, id.IpConfigurationName, id.PublicIPAddressName)
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.CloudServiceName, id.RoleInstanceName, id.NetworkInterfaceName, id.IpConfigurationName, id.PublicIPAddressName)
 }
 
 // Segments returns a slice of Resource ID Segments which comprise this Cloud Services Public I P Address ID
@@ -145,7 +145,7 @@ func (id CloudServicesPublicIPAddressId) Segments() []resourceids.Segment {
 		resourceids.StaticSegment("subscriptions", "subscriptions", "subscriptions"),
 		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
 		resourceids.StaticSegment("resourceGroups", "resourceGroups", "resourceGroups"),
-		resourceids.ResourceGroupSegment("resourceGroup", "example-resource-group"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
 		resourceids.StaticSegment("providers", "providers", "providers"),
 		resourceids.ResourceProviderSegment("resourceProvider", "Microsoft.Compute", "Microsoft.Compute"),
 		resourceids.StaticSegment("cloudServices", "cloudServices", "cloudServices"),
@@ -165,12 +165,12 @@ func (id CloudServicesPublicIPAddressId) Segments() []resourceids.Segment {
 func (id CloudServicesPublicIPAddressId) String() string {
 	components := []string{
 		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
-		fmt.Sprintf("Resource Group: %q", id.ResourceGroup),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
 		fmt.Sprintf("Cloud Service Name: %q", id.CloudServiceName),
 		fmt.Sprintf("Role Instance Name: %q", id.RoleInstanceName),
 		fmt.Sprintf("Network Interface Name: %q", id.NetworkInterfaceName),
 		fmt.Sprintf("Ip Configuration Name: %q", id.IpConfigurationName),
 		fmt.Sprintf("Public I P Address Name: %q", id.PublicIPAddressName),
 	}
-	return fmt.Sprintf("Cloud Services Public I P Address (%s)", strings.Join(components, "\n"))
+	return fmt.Sprintf("Cloud Services Public IP Address (%s)", strings.Join(components, "\n"))
 }

--- a/resourcemanager/commonids/cloud_services_public_ip_test.go
+++ b/resourcemanager/commonids/cloud_services_public_ip_test.go
@@ -15,8 +15,8 @@ func TestNewCloudServicesPublicIPAddressID(t *testing.T) {
 		t.Fatalf("Expected %q but got %q for Segment 'SubscriptionId'", id.SubscriptionId, "12345678-1234-9876-4563-123456789012")
 	}
 
-	if id.ResourceGroup != "example-resource-group" {
-		t.Fatalf("Expected %q but got %q for Segment 'ResourceGroup'", id.ResourceGroup, "example-resource-group")
+	if id.ResourceGroupName != "example-resource-group" {
+		t.Fatalf("Expected %q but got %q for Segment 'ResourceGroupName'", id.ResourceGroupName, "example-resource-group")
 	}
 
 	if id.CloudServiceName != "cloudServiceValue" {
@@ -139,7 +139,7 @@ func TestParseCloudServicesPublicIPAddressID(t *testing.T) {
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Compute/cloudServices/cloudServiceValue/roleInstances/roleInstanceValue/networkInterfaces/networkInterfaceValue/ipConfigurations/ipConfigurationValue/publicIPAddresses/publicIPAddressValue",
 			Expected: &CloudServicesPublicIPAddressId{
 				SubscriptionId:       "12345678-1234-9876-4563-123456789012",
-				ResourceGroup:        "example-resource-group",
+				ResourceGroupName:    "example-resource-group",
 				CloudServiceName:     "cloudServiceValue",
 				RoleInstanceName:     "roleInstanceValue",
 				NetworkInterfaceName: "networkInterfaceValue",
@@ -172,8 +172,8 @@ func TestParseCloudServicesPublicIPAddressID(t *testing.T) {
 			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
 		}
 
-		if actual.ResourceGroup != v.Expected.ResourceGroup {
-			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroupName, actual.ResourceGroupName)
 		}
 
 		if actual.CloudServiceName != v.Expected.CloudServiceName {
@@ -365,7 +365,7 @@ func TestParseCloudServicesPublicIPAddressIDInsensitively(t *testing.T) {
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Compute/cloudServices/cloudServiceValue/roleInstances/roleInstanceValue/networkInterfaces/networkInterfaceValue/ipConfigurations/ipConfigurationValue/publicIPAddresses/publicIPAddressValue",
 			Expected: &CloudServicesPublicIPAddressId{
 				SubscriptionId:       "12345678-1234-9876-4563-123456789012",
-				ResourceGroup:        "example-resource-group",
+				ResourceGroupName:    "example-resource-group",
 				CloudServiceName:     "cloudServiceValue",
 				RoleInstanceName:     "roleInstanceValue",
 				NetworkInterfaceName: "networkInterfaceValue",
@@ -383,7 +383,7 @@ func TestParseCloudServicesPublicIPAddressIDInsensitively(t *testing.T) {
 			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.cOmPuTe/cLoUdSeRvIcEs/cLoUdSeRvIcEvAlUe/rOlEiNsTaNcEs/rOlEiNsTaNcEvAlUe/nEtWoRkInTeRfAcEs/nEtWoRkInTeRfAcEvAlUe/iPcOnFiGuRaTiOnS/iPcOnFiGuRaTiOnVaLuE/pUbLiCiPaDdReSsEs/pUbLiCiPaDdReSsVaLuE",
 			Expected: &CloudServicesPublicIPAddressId{
 				SubscriptionId:       "12345678-1234-9876-4563-123456789012",
-				ResourceGroup:        "eXaMpLe-rEsOuRcE-GrOuP",
+				ResourceGroupName:    "eXaMpLe-rEsOuRcE-GrOuP",
 				CloudServiceName:     "cLoUdSeRvIcEvAlUe",
 				RoleInstanceName:     "rOlEiNsTaNcEvAlUe",
 				NetworkInterfaceName: "nEtWoRkInTeRfAcEvAlUe",
@@ -416,8 +416,8 @@ func TestParseCloudServicesPublicIPAddressIDInsensitively(t *testing.T) {
 			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
 		}
 
-		if actual.ResourceGroup != v.Expected.ResourceGroup {
-			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
 		}
 
 		if actual.CloudServiceName != v.Expected.CloudServiceName {

--- a/resourcemanager/commonids/express_route_circuit_peering.go
+++ b/resourcemanager/commonids/express_route_circuit_peering.go
@@ -11,19 +11,19 @@ var _ resourceids.ResourceId = ExpressRouteCircuitPeeringId{}
 
 // ExpressRouteCircuitPeeringId is a struct representing the Resource ID for a Express Route Circuit Peering
 type ExpressRouteCircuitPeeringId struct {
-	SubscriptionId string
-	ResourceGroup  string
-	CircuitName    string
-	PeeringName    string
+	SubscriptionId    string
+	ResourceGroupName string
+	CircuitName       string
+	PeeringName       string
 }
 
 // NewExpressRouteCircuitPeeringID returns a new ExpressRouteCircuitPeeringId struct
-func NewExpressRouteCircuitPeeringID(subscriptionId string, resourceGroup string, circuitName string, peeringName string) ExpressRouteCircuitPeeringId {
+func NewExpressRouteCircuitPeeringID(subscriptionId string, resourceGroupName string, circuitName string, peeringName string) ExpressRouteCircuitPeeringId {
 	return ExpressRouteCircuitPeeringId{
-		SubscriptionId: subscriptionId,
-		ResourceGroup:  resourceGroup,
-		CircuitName:    circuitName,
-		PeeringName:    peeringName,
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		CircuitName:       circuitName,
+		PeeringName:       peeringName,
 	}
 }
 
@@ -42,8 +42,8 @@ func ParseExpressRouteCircuitPeeringID(input string) (*ExpressRouteCircuitPeerin
 		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
 	}
 
-	if id.ResourceGroup, ok = parsed.Parsed["resourceGroup"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroup' was not found in the resource id %q", input)
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
 	}
 
 	if id.CircuitName, ok = parsed.Parsed["circuitName"]; !ok {
@@ -73,8 +73,8 @@ func ParseExpressRouteCircuitPeeringIDInsensitively(input string) (*ExpressRoute
 		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
 	}
 
-	if id.ResourceGroup, ok = parsed.Parsed["resourceGroup"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroup' was not found in the resource id %q", input)
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
 	}
 
 	if id.CircuitName, ok = parsed.Parsed["circuitName"]; !ok {
@@ -106,7 +106,7 @@ func ValidateExpressRouteCircuitPeeringID(input interface{}, key string) (warnin
 // ID returns the formatted Express Route Circuit Peering ID
 func (id ExpressRouteCircuitPeeringId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/expressRouteCircuits/%s/peerings/%s"
-	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.CircuitName, id.PeeringName)
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.CircuitName, id.PeeringName)
 }
 
 // Segments returns a slice of Resource ID Segments which comprise this Express Route Circuit Peering ID
@@ -115,7 +115,7 @@ func (id ExpressRouteCircuitPeeringId) Segments() []resourceids.Segment {
 		resourceids.StaticSegment("subscriptions", "subscriptions", "subscriptions"),
 		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
 		resourceids.StaticSegment("resourceGroups", "resourceGroups", "resourceGroups"),
-		resourceids.ResourceGroupSegment("resourceGroup", "example-resource-group"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
 		resourceids.StaticSegment("providers", "providers", "providers"),
 		resourceids.ResourceProviderSegment("resourceProvider", "Microsoft.Network", "Microsoft.Network"),
 		resourceids.StaticSegment("expressRouteCircuits", "expressRouteCircuits", "expressRouteCircuits"),
@@ -129,7 +129,7 @@ func (id ExpressRouteCircuitPeeringId) Segments() []resourceids.Segment {
 func (id ExpressRouteCircuitPeeringId) String() string {
 	components := []string{
 		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
-		fmt.Sprintf("Resource Group: %q", id.ResourceGroup),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
 		fmt.Sprintf("Circuit Name: %q", id.CircuitName),
 		fmt.Sprintf("Peering Name: %q", id.PeeringName),
 	}

--- a/resourcemanager/commonids/express_route_circuit_peering_test.go
+++ b/resourcemanager/commonids/express_route_circuit_peering_test.go
@@ -15,8 +15,8 @@ func TestNewExpressRouteCircuitPeeringID(t *testing.T) {
 		t.Fatalf("Expected %q but got %q for Segment 'SubscriptionId'", id.SubscriptionId, "12345678-1234-9876-4563-123456789012")
 	}
 
-	if id.ResourceGroup != "example-resource-group" {
-		t.Fatalf("Expected %q but got %q for Segment 'ResourceGroup'", id.ResourceGroup, "example-resource-group")
+	if id.ResourceGroupName != "example-resource-group" {
+		t.Fatalf("Expected %q but got %q for Segment 'ResourceGroupName'", id.ResourceGroupName, "example-resource-group")
 	}
 
 	if id.CircuitName != "circuitValue" {
@@ -96,10 +96,10 @@ func TestParseExpressRouteCircuitPeeringID(t *testing.T) {
 			// Valid URI
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Network/expressRouteCircuits/circuitValue/peerings/peeringValue",
 			Expected: &ExpressRouteCircuitPeeringId{
-				SubscriptionId: "12345678-1234-9876-4563-123456789012",
-				ResourceGroup:  "example-resource-group",
-				CircuitName:    "circuitValue",
-				PeeringName:    "peeringValue",
+				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName: "example-resource-group",
+				CircuitName:       "circuitValue",
+				PeeringName:       "peeringValue",
 			},
 		},
 		{
@@ -127,8 +127,8 @@ func TestParseExpressRouteCircuitPeeringID(t *testing.T) {
 			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
 		}
 
-		if actual.ResourceGroup != v.Expected.ResourceGroup {
-			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroupName, actual.ResourceGroupName)
 		}
 
 		if actual.CircuitName != v.Expected.CircuitName {
@@ -247,10 +247,10 @@ func TestParseExpressRouteCircuitPeeringIDInsensitively(t *testing.T) {
 			// Valid URI
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Network/expressRouteCircuits/circuitValue/peerings/peeringValue",
 			Expected: &ExpressRouteCircuitPeeringId{
-				SubscriptionId: "12345678-1234-9876-4563-123456789012",
-				ResourceGroup:  "example-resource-group",
-				CircuitName:    "circuitValue",
-				PeeringName:    "peeringValue",
+				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName: "example-resource-group",
+				CircuitName:       "circuitValue",
+				PeeringName:       "peeringValue",
 			},
 		},
 		{
@@ -262,10 +262,10 @@ func TestParseExpressRouteCircuitPeeringIDInsensitively(t *testing.T) {
 			// Valid URI (mIxEd CaSe since this is insensitive)
 			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.nEtWoRk/eXpReSsRoUtEcIrCuItS/cIrCuItVaLuE/pEeRiNgS/pEeRiNgVaLuE",
 			Expected: &ExpressRouteCircuitPeeringId{
-				SubscriptionId: "12345678-1234-9876-4563-123456789012",
-				ResourceGroup:  "eXaMpLe-rEsOuRcE-GrOuP",
-				CircuitName:    "cIrCuItVaLuE",
-				PeeringName:    "pEeRiNgVaLuE",
+				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName: "eXaMpLe-rEsOuRcE-GrOuP",
+				CircuitName:       "cIrCuItVaLuE",
+				PeeringName:       "pEeRiNgVaLuE",
 			},
 		},
 		{
@@ -293,8 +293,8 @@ func TestParseExpressRouteCircuitPeeringIDInsensitively(t *testing.T) {
 			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
 		}
 
-		if actual.ResourceGroup != v.Expected.ResourceGroup {
-			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
 		}
 
 		if actual.CircuitName != v.Expected.CircuitName {

--- a/resourcemanager/commonids/network_interface.go
+++ b/resourcemanager/commonids/network_interface.go
@@ -12,15 +12,15 @@ var _ resourceids.ResourceId = NetworkInterfaceId{}
 // NetworkInterfaceId is a struct representing the Resource ID for a Network Interface
 type NetworkInterfaceId struct {
 	SubscriptionId       string
-	ResourceGroup        string
+	ResourceGroupName    string
 	NetworkInterfaceName string
 }
 
 // NewNetworkInterfaceID returns a new NetworkInterfaceId struct
-func NewNetworkInterfaceID(subscriptionId string, resourceGroup string, networkInterfaceName string) NetworkInterfaceId {
+func NewNetworkInterfaceID(subscriptionId string, resourceGroupName string, networkInterfaceName string) NetworkInterfaceId {
 	return NetworkInterfaceId{
 		SubscriptionId:       subscriptionId,
-		ResourceGroup:        resourceGroup,
+		ResourceGroupName:    resourceGroupName,
 		NetworkInterfaceName: networkInterfaceName,
 	}
 }
@@ -40,8 +40,8 @@ func ParseNetworkInterfaceID(input string) (*NetworkInterfaceId, error) {
 		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
 	}
 
-	if id.ResourceGroup, ok = parsed.Parsed["resourceGroup"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroup' was not found in the resource id %q", input)
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
 	}
 
 	if id.NetworkInterfaceName, ok = parsed.Parsed["networkInterfaceName"]; !ok {
@@ -67,8 +67,8 @@ func ParseNetworkInterfaceIDInsensitively(input string) (*NetworkInterfaceId, er
 		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
 	}
 
-	if id.ResourceGroup, ok = parsed.Parsed["resourceGroup"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroup' was not found in the resource id %q", input)
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
 	}
 
 	if id.NetworkInterfaceName, ok = parsed.Parsed["networkInterfaceName"]; !ok {
@@ -96,7 +96,7 @@ func ValidateNetworkInterfaceID(input interface{}, key string) (warnings []strin
 // ID returns the formatted Network Interface ID
 func (id NetworkInterfaceId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/networkInterfaces/%s"
-	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.NetworkInterfaceName)
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.NetworkInterfaceName)
 }
 
 // Segments returns a slice of Resource ID Segments which comprise this Network Interface ID
@@ -105,7 +105,7 @@ func (id NetworkInterfaceId) Segments() []resourceids.Segment {
 		resourceids.StaticSegment("subscriptions", "subscriptions", "subscriptions"),
 		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
 		resourceids.StaticSegment("resourceGroups", "resourceGroups", "resourceGroups"),
-		resourceids.ResourceGroupSegment("resourceGroup", "example-resource-group"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
 		resourceids.StaticSegment("providers", "providers", "providers"),
 		resourceids.ResourceProviderSegment("resourceProvider", "Microsoft.Network", "Microsoft.Network"),
 		resourceids.StaticSegment("networkInterfaces", "networkInterfaces", "networkInterfaces"),
@@ -117,7 +117,7 @@ func (id NetworkInterfaceId) Segments() []resourceids.Segment {
 func (id NetworkInterfaceId) String() string {
 	components := []string{
 		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
-		fmt.Sprintf("Resource Group: %q", id.ResourceGroup),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
 		fmt.Sprintf("Network Interface Name: %q", id.NetworkInterfaceName),
 	}
 	return fmt.Sprintf("Network Interface (%s)", strings.Join(components, "\n"))

--- a/resourcemanager/commonids/network_interface_ip_configuration.go
+++ b/resourcemanager/commonids/network_interface_ip_configuration.go
@@ -12,16 +12,16 @@ var _ resourceids.ResourceId = NetworkInterfaceIPConfigurationId{}
 // NetworkInterfaceIPConfigurationId is a struct representing the Resource ID for a Network Interface I P Configuration
 type NetworkInterfaceIPConfigurationId struct {
 	SubscriptionId       string
-	ResourceGroup        string
+	ResourceGroupName    string
 	NetworkInterfaceName string
 	IpConfigurationName  string
 }
 
 // NewNetworkInterfaceIPConfigurationID returns a new NetworkInterfaceIPConfigurationId struct
-func NewNetworkInterfaceIPConfigurationID(subscriptionId string, resourceGroup string, networkInterfaceName string, ipConfigurationName string) NetworkInterfaceIPConfigurationId {
+func NewNetworkInterfaceIPConfigurationID(subscriptionId string, resourceGroupName string, networkInterfaceName string, ipConfigurationName string) NetworkInterfaceIPConfigurationId {
 	return NetworkInterfaceIPConfigurationId{
 		SubscriptionId:       subscriptionId,
-		ResourceGroup:        resourceGroup,
+		ResourceGroupName:    resourceGroupName,
 		NetworkInterfaceName: networkInterfaceName,
 		IpConfigurationName:  ipConfigurationName,
 	}
@@ -42,8 +42,8 @@ func ParseNetworkInterfaceIPConfigurationID(input string) (*NetworkInterfaceIPCo
 		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
 	}
 
-	if id.ResourceGroup, ok = parsed.Parsed["resourceGroup"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroup' was not found in the resource id %q", input)
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
 	}
 
 	if id.NetworkInterfaceName, ok = parsed.Parsed["networkInterfaceName"]; !ok {
@@ -73,8 +73,8 @@ func ParseNetworkInterfaceIPConfigurationIDInsensitively(input string) (*Network
 		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
 	}
 
-	if id.ResourceGroup, ok = parsed.Parsed["resourceGroup"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroup' was not found in the resource id %q", input)
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
 	}
 
 	if id.NetworkInterfaceName, ok = parsed.Parsed["networkInterfaceName"]; !ok {
@@ -106,7 +106,7 @@ func ValidateNetworkInterfaceIPConfigurationID(input interface{}, key string) (w
 // ID returns the formatted Network Interface I P Configuration ID
 func (id NetworkInterfaceIPConfigurationId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/networkInterfaces/%s/ipConfigurations/%s"
-	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.NetworkInterfaceName, id.IpConfigurationName)
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.NetworkInterfaceName, id.IpConfigurationName)
 }
 
 // Segments returns a slice of Resource ID Segments which comprise this Network Interface I P Configuration ID
@@ -115,7 +115,7 @@ func (id NetworkInterfaceIPConfigurationId) Segments() []resourceids.Segment {
 		resourceids.StaticSegment("subscriptions", "subscriptions", "subscriptions"),
 		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
 		resourceids.StaticSegment("resourceGroups", "resourceGroups", "resourceGroups"),
-		resourceids.ResourceGroupSegment("resourceGroup", "example-resource-group"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
 		resourceids.StaticSegment("providers", "providers", "providers"),
 		resourceids.ResourceProviderSegment("resourceProvider", "Microsoft.Network", "Microsoft.Network"),
 		resourceids.StaticSegment("networkInterfaces", "networkInterfaces", "networkInterfaces"),
@@ -129,7 +129,7 @@ func (id NetworkInterfaceIPConfigurationId) Segments() []resourceids.Segment {
 func (id NetworkInterfaceIPConfigurationId) String() string {
 	components := []string{
 		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
-		fmt.Sprintf("Resource Group: %q", id.ResourceGroup),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
 		fmt.Sprintf("Network Interface Name: %q", id.NetworkInterfaceName),
 		fmt.Sprintf("Ip Configuration Name: %q", id.IpConfigurationName),
 	}

--- a/resourcemanager/commonids/network_interface_ip_configuration_test.go
+++ b/resourcemanager/commonids/network_interface_ip_configuration_test.go
@@ -15,8 +15,8 @@ func TestNewNetworkInterfaceIPConfigurationID(t *testing.T) {
 		t.Fatalf("Expected %q but got %q for Segment 'SubscriptionId'", id.SubscriptionId, "12345678-1234-9876-4563-123456789012")
 	}
 
-	if id.ResourceGroup != "example-resource-group" {
-		t.Fatalf("Expected %q but got %q for Segment 'ResourceGroup'", id.ResourceGroup, "example-resource-group")
+	if id.ResourceGroupName != "example-resource-group" {
+		t.Fatalf("Expected %q but got %q for Segment 'ResourceGroupName'", id.ResourceGroupName, "example-resource-group")
 	}
 
 	if id.NetworkInterfaceName != "networkInterfaceValue" {
@@ -97,7 +97,7 @@ func TestParseNetworkInterfaceIPConfigurationID(t *testing.T) {
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Network/networkInterfaces/networkInterfaceValue/ipConfigurations/ipConfigurationValue",
 			Expected: &NetworkInterfaceIPConfigurationId{
 				SubscriptionId:       "12345678-1234-9876-4563-123456789012",
-				ResourceGroup:        "example-resource-group",
+				ResourceGroupName:    "example-resource-group",
 				NetworkInterfaceName: "networkInterfaceValue",
 				IpConfigurationName:  "ipConfigurationValue",
 			},
@@ -127,8 +127,8 @@ func TestParseNetworkInterfaceIPConfigurationID(t *testing.T) {
 			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
 		}
 
-		if actual.ResourceGroup != v.Expected.ResourceGroup {
-			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
 		}
 
 		if actual.NetworkInterfaceName != v.Expected.NetworkInterfaceName {
@@ -248,7 +248,7 @@ func TestParseNetworkInterfaceIPConfigurationIDInsensitively(t *testing.T) {
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Network/networkInterfaces/networkInterfaceValue/ipConfigurations/ipConfigurationValue",
 			Expected: &NetworkInterfaceIPConfigurationId{
 				SubscriptionId:       "12345678-1234-9876-4563-123456789012",
-				ResourceGroup:        "example-resource-group",
+				ResourceGroupName:    "example-resource-group",
 				NetworkInterfaceName: "networkInterfaceValue",
 				IpConfigurationName:  "ipConfigurationValue",
 			},
@@ -263,7 +263,7 @@ func TestParseNetworkInterfaceIPConfigurationIDInsensitively(t *testing.T) {
 			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.nEtWoRk/nEtWoRkInTeRfAcEs/nEtWoRkInTeRfAcEvAlUe/iPcOnFiGuRaTiOnS/iPcOnFiGuRaTiOnVaLuE",
 			Expected: &NetworkInterfaceIPConfigurationId{
 				SubscriptionId:       "12345678-1234-9876-4563-123456789012",
-				ResourceGroup:        "eXaMpLe-rEsOuRcE-GrOuP",
+				ResourceGroupName:    "eXaMpLe-rEsOuRcE-GrOuP",
 				NetworkInterfaceName: "nEtWoRkInTeRfAcEvAlUe",
 				IpConfigurationName:  "iPcOnFiGuRaTiOnVaLuE",
 			},
@@ -293,8 +293,8 @@ func TestParseNetworkInterfaceIPConfigurationIDInsensitively(t *testing.T) {
 			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
 		}
 
-		if actual.ResourceGroup != v.Expected.ResourceGroup {
-			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
 		}
 
 		if actual.NetworkInterfaceName != v.Expected.NetworkInterfaceName {

--- a/resourcemanager/commonids/network_interface_test.go
+++ b/resourcemanager/commonids/network_interface_test.go
@@ -15,8 +15,8 @@ func TestNewNetworkInterfaceID(t *testing.T) {
 		t.Fatalf("Expected %q but got %q for Segment 'SubscriptionId'", id.SubscriptionId, "12345678-1234-9876-4563-123456789012")
 	}
 
-	if id.ResourceGroup != "example-resource-group" {
-		t.Fatalf("Expected %q but got %q for Segment 'ResourceGroup'", id.ResourceGroup, "example-resource-group")
+	if id.ResourceGroupName != "example-resource-group" {
+		t.Fatalf("Expected %q but got %q for Segment 'ResourceGroupName'", id.ResourceGroupName, "example-resource-group")
 	}
 
 	if id.NetworkInterfaceName != "networkInterfaceValue" {
@@ -83,7 +83,7 @@ func TestParseNetworkInterfaceID(t *testing.T) {
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Network/networkInterfaces/networkInterfaceValue",
 			Expected: &NetworkInterfaceId{
 				SubscriptionId:       "12345678-1234-9876-4563-123456789012",
-				ResourceGroup:        "example-resource-group",
+				ResourceGroupName:    "example-resource-group",
 				NetworkInterfaceName: "networkInterfaceValue",
 			},
 		},
@@ -112,8 +112,8 @@ func TestParseNetworkInterfaceID(t *testing.T) {
 			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
 		}
 
-		if actual.ResourceGroup != v.Expected.ResourceGroup {
-			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
 		}
 
 		if actual.NetworkInterfaceName != v.Expected.NetworkInterfaceName {
@@ -209,7 +209,7 @@ func TestParseNetworkInterfaceIDInsensitively(t *testing.T) {
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Network/networkInterfaces/networkInterfaceValue",
 			Expected: &NetworkInterfaceId{
 				SubscriptionId:       "12345678-1234-9876-4563-123456789012",
-				ResourceGroup:        "example-resource-group",
+				ResourceGroupName:    "example-resource-group",
 				NetworkInterfaceName: "networkInterfaceValue",
 			},
 		},
@@ -223,7 +223,7 @@ func TestParseNetworkInterfaceIDInsensitively(t *testing.T) {
 			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.nEtWoRk/nEtWoRkInTeRfAcEs/nEtWoRkInTeRfAcEvAlUe",
 			Expected: &NetworkInterfaceId{
 				SubscriptionId:       "12345678-1234-9876-4563-123456789012",
-				ResourceGroup:        "eXaMpLe-rEsOuRcE-GrOuP",
+				ResourceGroupName:    "eXaMpLe-rEsOuRcE-GrOuP",
 				NetworkInterfaceName: "nEtWoRkInTeRfAcEvAlUe",
 			},
 		},
@@ -252,8 +252,8 @@ func TestParseNetworkInterfaceIDInsensitively(t *testing.T) {
 			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
 		}
 
-		if actual.ResourceGroup != v.Expected.ResourceGroup {
-			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
 		}
 
 		if actual.NetworkInterfaceName != v.Expected.NetworkInterfaceName {

--- a/resourcemanager/commonids/public_ip_address.go
+++ b/resourcemanager/commonids/public_ip_address.go
@@ -12,15 +12,15 @@ var _ resourceids.ResourceId = PublicIPAddressId{}
 // PublicIPAddressId is a struct representing the Resource ID for a Public I P Address
 type PublicIPAddressId struct {
 	SubscriptionId        string
-	ResourceGroup         string
+	ResourceGroupName     string
 	PublicIPAddressesName string
 }
 
 // NewPublicIPAddressID returns a new PublicIPAddressId struct
-func NewPublicIPAddressID(subscriptionId string, resourceGroup string, publicIPAddressesName string) PublicIPAddressId {
+func NewPublicIPAddressID(subscriptionId string, resourceGroupName string, publicIPAddressesName string) PublicIPAddressId {
 	return PublicIPAddressId{
 		SubscriptionId:        subscriptionId,
-		ResourceGroup:         resourceGroup,
+		ResourceGroupName:     resourceGroupName,
 		PublicIPAddressesName: publicIPAddressesName,
 	}
 }
@@ -40,8 +40,8 @@ func ParsePublicIPAddressID(input string) (*PublicIPAddressId, error) {
 		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
 	}
 
-	if id.ResourceGroup, ok = parsed.Parsed["resourceGroup"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroup' was not found in the resource id %q", input)
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
 	}
 
 	if id.PublicIPAddressesName, ok = parsed.Parsed["publicIPAddressesName"]; !ok {
@@ -67,8 +67,8 @@ func ParsePublicIPAddressIDInsensitively(input string) (*PublicIPAddressId, erro
 		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
 	}
 
-	if id.ResourceGroup, ok = parsed.Parsed["resourceGroup"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroup' was not found in the resource id %q", input)
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
 	}
 
 	if id.PublicIPAddressesName, ok = parsed.Parsed["publicIPAddressesName"]; !ok {
@@ -96,7 +96,7 @@ func ValidatePublicIPAddressID(input interface{}, key string) (warnings []string
 // ID returns the formatted Public I P Address ID
 func (id PublicIPAddressId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/publicIPAddresses/%s"
-	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.PublicIPAddressesName)
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.PublicIPAddressesName)
 }
 
 // Segments returns a slice of Resource ID Segments which comprise this Public I P Address ID
@@ -105,7 +105,7 @@ func (id PublicIPAddressId) Segments() []resourceids.Segment {
 		resourceids.StaticSegment("subscriptions", "subscriptions", "subscriptions"),
 		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
 		resourceids.StaticSegment("resourceGroups", "resourceGroups", "resourceGroups"),
-		resourceids.ResourceGroupSegment("resourceGroup", "example-resource-group"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
 		resourceids.StaticSegment("providers", "providers", "providers"),
 		resourceids.ResourceProviderSegment("resourceProvider", "Microsoft.Network", "Microsoft.Network"),
 		resourceids.StaticSegment("publicIPAddresses", "publicIPAddresses", "publicIPAddresses"),
@@ -117,7 +117,7 @@ func (id PublicIPAddressId) Segments() []resourceids.Segment {
 func (id PublicIPAddressId) String() string {
 	components := []string{
 		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
-		fmt.Sprintf("Resource Group: %q", id.ResourceGroup),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
 		fmt.Sprintf("Public I P Addresses Name: %q", id.PublicIPAddressesName),
 	}
 	return fmt.Sprintf("Public I P Address (%s)", strings.Join(components, "\n"))

--- a/resourcemanager/commonids/public_ip_address_test.go
+++ b/resourcemanager/commonids/public_ip_address_test.go
@@ -15,8 +15,8 @@ func TestNewPublicIPAddressID(t *testing.T) {
 		t.Fatalf("Expected %q but got %q for Segment 'SubscriptionId'", id.SubscriptionId, "12345678-1234-9876-4563-123456789012")
 	}
 
-	if id.ResourceGroup != "example-resource-group" {
-		t.Fatalf("Expected %q but got %q for Segment 'ResourceGroup'", id.ResourceGroup, "example-resource-group")
+	if id.ResourceGroupName != "example-resource-group" {
+		t.Fatalf("Expected %q but got %q for Segment 'ResourceGroupName'", id.ResourceGroupName, "example-resource-group")
 	}
 
 	if id.PublicIPAddressesName != "publicIPAddressesValue" {
@@ -83,7 +83,7 @@ func TestParsePublicIPAddressID(t *testing.T) {
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Network/publicIPAddresses/publicIPAddressesValue",
 			Expected: &PublicIPAddressId{
 				SubscriptionId:        "12345678-1234-9876-4563-123456789012",
-				ResourceGroup:         "example-resource-group",
+				ResourceGroupName:     "example-resource-group",
 				PublicIPAddressesName: "publicIPAddressesValue",
 			},
 		},
@@ -112,8 +112,8 @@ func TestParsePublicIPAddressID(t *testing.T) {
 			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
 		}
 
-		if actual.ResourceGroup != v.Expected.ResourceGroup {
-			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
 		}
 
 		if actual.PublicIPAddressesName != v.Expected.PublicIPAddressesName {
@@ -209,7 +209,7 @@ func TestParsePublicIPAddressIDInsensitively(t *testing.T) {
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Network/publicIPAddresses/publicIPAddressesValue",
 			Expected: &PublicIPAddressId{
 				SubscriptionId:        "12345678-1234-9876-4563-123456789012",
-				ResourceGroup:         "example-resource-group",
+				ResourceGroupName:     "example-resource-group",
 				PublicIPAddressesName: "publicIPAddressesValue",
 			},
 		},
@@ -223,7 +223,7 @@ func TestParsePublicIPAddressIDInsensitively(t *testing.T) {
 			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.nEtWoRk/pUbLiCiPaDdReSsEs/pUbLiCiPaDdReSsEsVaLuE",
 			Expected: &PublicIPAddressId{
 				SubscriptionId:        "12345678-1234-9876-4563-123456789012",
-				ResourceGroup:         "eXaMpLe-rEsOuRcE-GrOuP",
+				ResourceGroupName:     "eXaMpLe-rEsOuRcE-GrOuP",
 				PublicIPAddressesName: "pUbLiCiPaDdReSsEsVaLuE",
 			},
 		},
@@ -252,8 +252,8 @@ func TestParsePublicIPAddressIDInsensitively(t *testing.T) {
 			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
 		}
 
-		if actual.ResourceGroup != v.Expected.ResourceGroup {
-			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
 		}
 
 		if actual.PublicIPAddressesName != v.Expected.PublicIPAddressesName {

--- a/resourcemanager/commonids/virtual_hub_bgp_connection.go
+++ b/resourcemanager/commonids/virtual_hub_bgp_connection.go
@@ -11,19 +11,19 @@ var _ resourceids.ResourceId = VirtualHubBGPConnectionId{}
 
 // VirtualHubBGPConnectionId is a struct representing the Resource ID for a Virtual Hub B G P Connection
 type VirtualHubBGPConnectionId struct {
-	SubscriptionId string
-	ResourceGroup  string
-	HubName        string
-	ConnectionName string
+	SubscriptionId    string
+	ResourceGroupName string
+	HubName           string
+	ConnectionName    string
 }
 
 // NewVirtualHubBGPConnectionID returns a new VirtualHubBGPConnectionId struct
-func NewVirtualHubBGPConnectionID(subscriptionId string, resourceGroup string, hubName string, connectionName string) VirtualHubBGPConnectionId {
+func NewVirtualHubBGPConnectionID(subscriptionId string, resourceGroupName string, hubName string, connectionName string) VirtualHubBGPConnectionId {
 	return VirtualHubBGPConnectionId{
-		SubscriptionId: subscriptionId,
-		ResourceGroup:  resourceGroup,
-		HubName:        hubName,
-		ConnectionName: connectionName,
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		HubName:           hubName,
+		ConnectionName:    connectionName,
 	}
 }
 
@@ -42,8 +42,8 @@ func ParseVirtualHubBGPConnectionID(input string) (*VirtualHubBGPConnectionId, e
 		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
 	}
 
-	if id.ResourceGroup, ok = parsed.Parsed["resourceGroup"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroup' was not found in the resource id %q", input)
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
 	}
 
 	if id.HubName, ok = parsed.Parsed["hubName"]; !ok {
@@ -73,8 +73,8 @@ func ParseVirtualHubBGPConnectionIDInsensitively(input string) (*VirtualHubBGPCo
 		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
 	}
 
-	if id.ResourceGroup, ok = parsed.Parsed["resourceGroup"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroup' was not found in the resource id %q", input)
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
 	}
 
 	if id.HubName, ok = parsed.Parsed["hubName"]; !ok {
@@ -106,7 +106,7 @@ func ValidateVirtualHubBGPConnectionID(input interface{}, key string) (warnings 
 // ID returns the formatted Virtual Hub B G P Connection ID
 func (id VirtualHubBGPConnectionId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualHubs/%s/bgpConnections/%s"
-	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.HubName, id.ConnectionName)
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.HubName, id.ConnectionName)
 }
 
 // Segments returns a slice of Resource ID Segments which comprise this Virtual Hub B G P Connection ID
@@ -115,7 +115,7 @@ func (id VirtualHubBGPConnectionId) Segments() []resourceids.Segment {
 		resourceids.StaticSegment("subscriptions", "subscriptions", "subscriptions"),
 		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
 		resourceids.StaticSegment("resourceGroups", "resourceGroups", "resourceGroups"),
-		resourceids.ResourceGroupSegment("resourceGroup", "example-resource-group"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
 		resourceids.StaticSegment("providers", "providers", "providers"),
 		resourceids.ResourceProviderSegment("resourceProvider", "Microsoft.Network", "Microsoft.Network"),
 		resourceids.StaticSegment("virtualHubs", "virtualHubs", "virtualHubs"),
@@ -129,9 +129,9 @@ func (id VirtualHubBGPConnectionId) Segments() []resourceids.Segment {
 func (id VirtualHubBGPConnectionId) String() string {
 	components := []string{
 		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
-		fmt.Sprintf("Resource Group: %q", id.ResourceGroup),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
 		fmt.Sprintf("Hub Name: %q", id.HubName),
 		fmt.Sprintf("Connection Name: %q", id.ConnectionName),
 	}
-	return fmt.Sprintf("Virtual Hub B G P Connection (%s)", strings.Join(components, "\n"))
+	return fmt.Sprintf("Virtual Hub BGP Connection (%s)", strings.Join(components, "\n"))
 }

--- a/resourcemanager/commonids/virtual_hub_bgp_connection_test.go
+++ b/resourcemanager/commonids/virtual_hub_bgp_connection_test.go
@@ -15,8 +15,8 @@ func TestNewVirtualHubBGPConnectionID(t *testing.T) {
 		t.Fatalf("Expected %q but got %q for Segment 'SubscriptionId'", id.SubscriptionId, "12345678-1234-9876-4563-123456789012")
 	}
 
-	if id.ResourceGroup != "example-resource-group" {
-		t.Fatalf("Expected %q but got %q for Segment 'ResourceGroup'", id.ResourceGroup, "example-resource-group")
+	if id.ResourceGroupName != "example-resource-group" {
+		t.Fatalf("Expected %q but got %q for Segment 'ResourceGroupName'", id.ResourceGroupName, "example-resource-group")
 	}
 
 	if id.HubName != "hubValue" {
@@ -96,10 +96,10 @@ func TestParseVirtualHubBGPConnectionID(t *testing.T) {
 			// Valid URI
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Network/virtualHubs/hubValue/bgpConnections/connectionValue",
 			Expected: &VirtualHubBGPConnectionId{
-				SubscriptionId: "12345678-1234-9876-4563-123456789012",
-				ResourceGroup:  "example-resource-group",
-				HubName:        "hubValue",
-				ConnectionName: "connectionValue",
+				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName: "example-resource-group",
+				HubName:           "hubValue",
+				ConnectionName:    "connectionValue",
 			},
 		},
 		{
@@ -127,8 +127,8 @@ func TestParseVirtualHubBGPConnectionID(t *testing.T) {
 			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
 		}
 
-		if actual.ResourceGroup != v.Expected.ResourceGroup {
-			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
 		}
 
 		if actual.HubName != v.Expected.HubName {
@@ -247,10 +247,10 @@ func TestParseVirtualHubBGPConnectionIDInsensitively(t *testing.T) {
 			// Valid URI
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Network/virtualHubs/hubValue/bgpConnections/connectionValue",
 			Expected: &VirtualHubBGPConnectionId{
-				SubscriptionId: "12345678-1234-9876-4563-123456789012",
-				ResourceGroup:  "example-resource-group",
-				HubName:        "hubValue",
-				ConnectionName: "connectionValue",
+				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName: "example-resource-group",
+				HubName:           "hubValue",
+				ConnectionName:    "connectionValue",
 			},
 		},
 		{
@@ -262,10 +262,10 @@ func TestParseVirtualHubBGPConnectionIDInsensitively(t *testing.T) {
 			// Valid URI (mIxEd CaSe since this is insensitive)
 			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.nEtWoRk/vIrTuAlHuBs/hUbVaLuE/bGpCoNnEcTiOnS/cOnNeCtIoNvAlUe",
 			Expected: &VirtualHubBGPConnectionId{
-				SubscriptionId: "12345678-1234-9876-4563-123456789012",
-				ResourceGroup:  "eXaMpLe-rEsOuRcE-GrOuP",
-				HubName:        "hUbVaLuE",
-				ConnectionName: "cOnNeCtIoNvAlUe",
+				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName: "eXaMpLe-rEsOuRcE-GrOuP",
+				HubName:           "hUbVaLuE",
+				ConnectionName:    "cOnNeCtIoNvAlUe",
 			},
 		},
 		{
@@ -293,8 +293,8 @@ func TestParseVirtualHubBGPConnectionIDInsensitively(t *testing.T) {
 			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
 		}
 
-		if actual.ResourceGroup != v.Expected.ResourceGroup {
-			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
 		}
 
 		if actual.HubName != v.Expected.HubName {

--- a/resourcemanager/commonids/virtual_hub_ip_configuration.go
+++ b/resourcemanager/commonids/virtual_hub_ip_configuration.go
@@ -11,19 +11,19 @@ var _ resourceids.ResourceId = VirtualHubIPConfigurationId{}
 
 // VirtualHubIPConfigurationId is a struct representing the Resource ID for a Virtual Hub I P Configuration
 type VirtualHubIPConfigurationId struct {
-	SubscriptionId string
-	ResourceGroup  string
-	VirtualHubName string
-	IpConfigName   string
+	SubscriptionId    string
+	ResourceGroupName string
+	VirtualHubName    string
+	IpConfigName      string
 }
 
 // NewVirtualHubIPConfigurationID returns a new VirtualHubIPConfigurationId struct
-func NewVirtualHubIPConfigurationID(subscriptionId string, resourceGroup string, virtualHubName string, ipConfigName string) VirtualHubIPConfigurationId {
+func NewVirtualHubIPConfigurationID(subscriptionId string, resourceGroupName string, virtualHubName string, ipConfigName string) VirtualHubIPConfigurationId {
 	return VirtualHubIPConfigurationId{
-		SubscriptionId: subscriptionId,
-		ResourceGroup:  resourceGroup,
-		VirtualHubName: virtualHubName,
-		IpConfigName:   ipConfigName,
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		VirtualHubName:    virtualHubName,
+		IpConfigName:      ipConfigName,
 	}
 }
 
@@ -42,8 +42,8 @@ func ParseVirtualHubIPConfigurationID(input string) (*VirtualHubIPConfigurationI
 		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
 	}
 
-	if id.ResourceGroup, ok = parsed.Parsed["resourceGroup"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroup' was not found in the resource id %q", input)
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
 	}
 
 	if id.VirtualHubName, ok = parsed.Parsed["virtualHubName"]; !ok {
@@ -73,8 +73,8 @@ func ParseVirtualHubIPConfigurationIDInsensitively(input string) (*VirtualHubIPC
 		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
 	}
 
-	if id.ResourceGroup, ok = parsed.Parsed["resourceGroup"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroup' was not found in the resource id %q", input)
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
 	}
 
 	if id.VirtualHubName, ok = parsed.Parsed["virtualHubName"]; !ok {
@@ -106,16 +106,16 @@ func ValidateVirtualHubIPConfigurationID(input interface{}, key string) (warning
 // ID returns the formatted Virtual Hub I P Configuration ID
 func (id VirtualHubIPConfigurationId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualHubs/%s/ipConfigurations/%s"
-	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.VirtualHubName, id.IpConfigName)
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.VirtualHubName, id.IpConfigName)
 }
 
-// Segments returns a slice of Resource ID Segments which comprise this Virtual Hub I P Configuration ID
+// Segments returns a slice of Resource ID Segments which comprise this Virtual Hub IP Configuration ID
 func (id VirtualHubIPConfigurationId) Segments() []resourceids.Segment {
 	return []resourceids.Segment{
 		resourceids.StaticSegment("subscriptions", "subscriptions", "subscriptions"),
 		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
 		resourceids.StaticSegment("resourceGroups", "resourceGroups", "resourceGroups"),
-		resourceids.ResourceGroupSegment("resourceGroup", "example-resource-group"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
 		resourceids.StaticSegment("providers", "providers", "providers"),
 		resourceids.ResourceProviderSegment("resourceProvider", "Microsoft.Network", "Microsoft.Network"),
 		resourceids.StaticSegment("virtualHubs", "virtualHubs", "virtualHubs"),
@@ -129,7 +129,7 @@ func (id VirtualHubIPConfigurationId) Segments() []resourceids.Segment {
 func (id VirtualHubIPConfigurationId) String() string {
 	components := []string{
 		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
-		fmt.Sprintf("Resource Group: %q", id.ResourceGroup),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
 		fmt.Sprintf("Virtual Hub Name: %q", id.VirtualHubName),
 		fmt.Sprintf("Ip Config Name: %q", id.IpConfigName),
 	}

--- a/resourcemanager/commonids/virtual_hub_ip_configuration_test.go
+++ b/resourcemanager/commonids/virtual_hub_ip_configuration_test.go
@@ -15,8 +15,8 @@ func TestNewVirtualHubIPConfigurationID(t *testing.T) {
 		t.Fatalf("Expected %q but got %q for Segment 'SubscriptionId'", id.SubscriptionId, "12345678-1234-9876-4563-123456789012")
 	}
 
-	if id.ResourceGroup != "example-resource-group" {
-		t.Fatalf("Expected %q but got %q for Segment 'ResourceGroup'", id.ResourceGroup, "example-resource-group")
+	if id.ResourceGroupName != "example-resource-group" {
+		t.Fatalf("Expected %q but got %q for Segment 'ResourceGroupName'", id.ResourceGroupName, "example-resource-group")
 	}
 
 	if id.VirtualHubName != "virtualHubValue" {
@@ -96,10 +96,10 @@ func TestParseVirtualHubIPConfigurationID(t *testing.T) {
 			// Valid URI
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Network/virtualHubs/virtualHubValue/ipConfigurations/ipConfigValue",
 			Expected: &VirtualHubIPConfigurationId{
-				SubscriptionId: "12345678-1234-9876-4563-123456789012",
-				ResourceGroup:  "example-resource-group",
-				VirtualHubName: "virtualHubValue",
-				IpConfigName:   "ipConfigValue",
+				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName: "example-resource-group",
+				VirtualHubName:    "virtualHubValue",
+				IpConfigName:      "ipConfigValue",
 			},
 		},
 		{
@@ -127,8 +127,8 @@ func TestParseVirtualHubIPConfigurationID(t *testing.T) {
 			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
 		}
 
-		if actual.ResourceGroup != v.Expected.ResourceGroup {
-			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
 		}
 
 		if actual.VirtualHubName != v.Expected.VirtualHubName {
@@ -247,10 +247,10 @@ func TestParseVirtualHubIPConfigurationIDInsensitively(t *testing.T) {
 			// Valid URI
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Network/virtualHubs/virtualHubValue/ipConfigurations/ipConfigValue",
 			Expected: &VirtualHubIPConfigurationId{
-				SubscriptionId: "12345678-1234-9876-4563-123456789012",
-				ResourceGroup:  "example-resource-group",
-				VirtualHubName: "virtualHubValue",
-				IpConfigName:   "ipConfigValue",
+				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName: "example-resource-group",
+				VirtualHubName:    "virtualHubValue",
+				IpConfigName:      "ipConfigValue",
 			},
 		},
 		{
@@ -262,10 +262,10 @@ func TestParseVirtualHubIPConfigurationIDInsensitively(t *testing.T) {
 			// Valid URI (mIxEd CaSe since this is insensitive)
 			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.nEtWoRk/vIrTuAlHuBs/vIrTuAlHuBvAlUe/iPcOnFiGuRaTiOnS/iPcOnFiGvAlUe",
 			Expected: &VirtualHubIPConfigurationId{
-				SubscriptionId: "12345678-1234-9876-4563-123456789012",
-				ResourceGroup:  "eXaMpLe-rEsOuRcE-GrOuP",
-				VirtualHubName: "vIrTuAlHuBvAlUe",
-				IpConfigName:   "iPcOnFiGvAlUe",
+				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName: "eXaMpLe-rEsOuRcE-GrOuP",
+				VirtualHubName:    "vIrTuAlHuBvAlUe",
+				IpConfigName:      "iPcOnFiGvAlUe",
 			},
 		},
 		{
@@ -293,8 +293,8 @@ func TestParseVirtualHubIPConfigurationIDInsensitively(t *testing.T) {
 			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
 		}
 
-		if actual.ResourceGroup != v.Expected.ResourceGroup {
-			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
 		}
 
 		if actual.VirtualHubName != v.Expected.VirtualHubName {

--- a/resourcemanager/commonids/virtual_machine_scale_set_ip_configuration.go
+++ b/resourcemanager/commonids/virtual_machine_scale_set_ip_configuration.go
@@ -12,7 +12,7 @@ var _ resourceids.ResourceId = VirtualMachineScaleSetIPConfigurationId{}
 // VirtualMachineScaleSetIPConfigurationId is a struct representing the Resource ID for a Virtual Machine Scale Set Public I P Address
 type VirtualMachineScaleSetIPConfigurationId struct {
 	SubscriptionId             string
-	ResourceGroup              string
+	ResourceGroupName          string
 	VirtualMachineScaleSetName string
 	VirtualMachineIndex        string
 	NetworkInterfaceName       string
@@ -20,10 +20,10 @@ type VirtualMachineScaleSetIPConfigurationId struct {
 }
 
 // NewVirtualMachineScaleSetIPConfigurationId returns a new VirtualMachineScaleSetIPConfigurationId struct
-func NewVirtualMachineScaleSetIPConfigurationID(subscriptionId string, resourceGroup string, virtualMachineScaleSetName string, virtualMachineIndex string, networkInterfaceName string, ipConfigurationName string) VirtualMachineScaleSetIPConfigurationId {
+func NewVirtualMachineScaleSetIPConfigurationID(subscriptionId string, resourceGroupName string, virtualMachineScaleSetName string, virtualMachineIndex string, networkInterfaceName string, ipConfigurationName string) VirtualMachineScaleSetIPConfigurationId {
 	return VirtualMachineScaleSetIPConfigurationId{
 		SubscriptionId:             subscriptionId,
-		ResourceGroup:              resourceGroup,
+		ResourceGroupName:          resourceGroupName,
 		VirtualMachineScaleSetName: virtualMachineScaleSetName,
 		VirtualMachineIndex:        virtualMachineIndex,
 		NetworkInterfaceName:       networkInterfaceName,
@@ -46,8 +46,8 @@ func ParseVirtualMachineScaleSetIPConfigurationId(input string) (*VirtualMachine
 		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
 	}
 
-	if id.ResourceGroup, ok = parsed.Parsed["resourceGroup"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroup' was not found in the resource id %q", input)
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
 	}
 
 	if id.VirtualMachineScaleSetName, ok = parsed.Parsed["virtualMachineScaleSetName"]; !ok {
@@ -85,8 +85,8 @@ func ParseVirtualMachineScaleSetIPConfigurationIdInsensitively(input string) (*V
 		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
 	}
 
-	if id.ResourceGroup, ok = parsed.Parsed["resourceGroup"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroup' was not found in the resource id %q", input)
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
 	}
 
 	if id.VirtualMachineScaleSetName, ok = parsed.Parsed["virtualMachineScaleSetName"]; !ok {
@@ -126,7 +126,7 @@ func ValidateVirtualMachineScaleSetIPConfigurationId(input interface{}, key stri
 // ID returns the formatted Virtual Machine Scale Set Public I P Address ID
 func (id VirtualMachineScaleSetIPConfigurationId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachineScaleSets/%s/virtualMachines/%s/networkInterfaces/%s/ipConfigurations/%s"
-	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.VirtualMachineScaleSetName, id.VirtualMachineIndex, id.NetworkInterfaceName, id.IpConfigurationName)
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.VirtualMachineScaleSetName, id.VirtualMachineIndex, id.NetworkInterfaceName, id.IpConfigurationName)
 }
 
 // Segments returns a slice of Resource ID Segments which comprise this Virtual Machine Scale Set Public I P Address ID
@@ -135,7 +135,7 @@ func (id VirtualMachineScaleSetIPConfigurationId) Segments() []resourceids.Segme
 		resourceids.StaticSegment("subscriptions", "subscriptions", "subscriptions"),
 		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
 		resourceids.StaticSegment("resourceGroups", "resourceGroups", "resourceGroups"),
-		resourceids.ResourceGroupSegment("resourceGroup", "example-resource-group"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
 		resourceids.StaticSegment("providers", "providers", "providers"),
 		resourceids.ResourceProviderSegment("resourceProvider", "Microsoft.Compute", "Microsoft.Compute"),
 		resourceids.StaticSegment("virtualMachineScaleSets", "virtualMachineScaleSets", "virtualMachineScaleSets"),
@@ -153,7 +153,7 @@ func (id VirtualMachineScaleSetIPConfigurationId) Segments() []resourceids.Segme
 func (id VirtualMachineScaleSetIPConfigurationId) String() string {
 	components := []string{
 		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
-		fmt.Sprintf("Resource Group: %q", id.ResourceGroup),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
 		fmt.Sprintf("Virtual Machine Scale Set Name: %q", id.VirtualMachineScaleSetName),
 		fmt.Sprintf("Virtual Machine Index: %q", id.VirtualMachineIndex),
 		fmt.Sprintf("Network Interface Name: %q", id.NetworkInterfaceName),

--- a/resourcemanager/commonids/virtual_machine_scale_set_ip_configuration_test.go
+++ b/resourcemanager/commonids/virtual_machine_scale_set_ip_configuration_test.go
@@ -15,8 +15,8 @@ func TestNewVirtualMachineScaleSetIPConfigurationID(t *testing.T) {
 		t.Fatalf("Expected %q but got %q for Segment 'SubscriptionId'", id.SubscriptionId, "12345678-1234-9876-4563-123456789012")
 	}
 
-	if id.ResourceGroup != "example-resource-group" {
-		t.Fatalf("Expected %q but got %q for Segment 'ResourceGroup'", id.ResourceGroup, "example-resource-group")
+	if id.ResourceGroupName != "example-resource-group" {
+		t.Fatalf("Expected %q but got %q for Segment 'ResourceGroupName'", id.ResourceGroupName, "example-resource-group")
 	}
 
 	if id.VirtualMachineScaleSetName != "virtualMachineScaleSetValue" {
@@ -126,7 +126,7 @@ func TestParseVirtualMachineScaleSetIPConfigurationID(t *testing.T) {
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Compute/virtualMachineScaleSets/virtualMachineScaleSetValue/virtualMachines/virtualMachineIndexValue/networkInterfaces/networkInterfaceValue/ipConfigurations/ipConfigurationValue",
 			Expected: &VirtualMachineScaleSetIPConfigurationId{
 				SubscriptionId:             "12345678-1234-9876-4563-123456789012",
-				ResourceGroup:              "example-resource-group",
+				ResourceGroupName:          "example-resource-group",
 				VirtualMachineScaleSetName: "virtualMachineScaleSetValue",
 				VirtualMachineIndex:        "virtualMachineIndexValue",
 				NetworkInterfaceName:       "networkInterfaceValue",
@@ -158,8 +158,8 @@ func TestParseVirtualMachineScaleSetIPConfigurationID(t *testing.T) {
 			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
 		}
 
-		if actual.ResourceGroup != v.Expected.ResourceGroup {
-			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroupName, actual.ResourceGroupName)
 		}
 
 		if actual.VirtualMachineScaleSetName != v.Expected.VirtualMachineScaleSetName {
@@ -327,7 +327,7 @@ func TestParseVirtualMachineScaleSetIPConfigurationIDInsensitively(t *testing.T)
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Compute/virtualMachineScaleSets/virtualMachineScaleSetValue/virtualMachines/virtualMachineIndexValue/networkInterfaces/networkInterfaceValue/ipConfigurations/ipConfigurationValue",
 			Expected: &VirtualMachineScaleSetIPConfigurationId{
 				SubscriptionId:             "12345678-1234-9876-4563-123456789012",
-				ResourceGroup:              "example-resource-group",
+				ResourceGroupName:          "example-resource-group",
 				VirtualMachineScaleSetName: "virtualMachineScaleSetValue",
 				VirtualMachineIndex:        "virtualMachineIndexValue",
 				NetworkInterfaceName:       "networkInterfaceValue",
@@ -344,7 +344,7 @@ func TestParseVirtualMachineScaleSetIPConfigurationIDInsensitively(t *testing.T)
 			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.cOmPuTe/vIrTuAlMaChInEsCaLeSeTs/vIrTuAlMaChInEsCaLeSeTvAlUe/vIrTuAlMaChInEs/vIrTuAlMaChInEiNdExVaLuE/nEtWoRkInTeRfAcEs/nEtWoRkInTeRfAcEvAlUe/iPcOnFiGuRaTiOnS/iPcOnFiGuRaTiOnVaLuE",
 			Expected: &VirtualMachineScaleSetIPConfigurationId{
 				SubscriptionId:             "12345678-1234-9876-4563-123456789012",
-				ResourceGroup:              "eXaMpLe-rEsOuRcE-GrOuP",
+				ResourceGroupName:          "eXaMpLe-rEsOuRcE-GrOuP",
 				VirtualMachineScaleSetName: "vIrTuAlMaChInEsCaLeSeTvAlUe",
 				VirtualMachineIndex:        "vIrTuAlMaChInEiNdExVaLuE",
 				NetworkInterfaceName:       "nEtWoRkInTeRfAcEvAlUe",
@@ -376,8 +376,8 @@ func TestParseVirtualMachineScaleSetIPConfigurationIDInsensitively(t *testing.T)
 			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
 		}
 
-		if actual.ResourceGroup != v.Expected.ResourceGroup {
-			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
 		}
 
 		if actual.VirtualMachineScaleSetName != v.Expected.VirtualMachineScaleSetName {
@@ -395,7 +395,7 @@ func TestParseVirtualMachineScaleSetIPConfigurationIDInsensitively(t *testing.T)
 		if actual.IpConfigurationName != v.Expected.IpConfigurationName {
 			t.Fatalf("Expected %q but got %q for IpConfigurationName", v.Expected.IpConfigurationName, actual.IpConfigurationName)
 		}
-		
+
 	}
 }
 

--- a/resourcemanager/commonids/virtual_machine_scale_set_network_interface.go
+++ b/resourcemanager/commonids/virtual_machine_scale_set_network_interface.go
@@ -12,17 +12,17 @@ var _ resourceids.ResourceId = VirtualMachineScaleSetNetworkInterfaceId{}
 // VirtualMachineScaleSetNetworkInterfaceId is a struct representing the Resource ID for a Virtual Machine Scale Set Network Interface
 type VirtualMachineScaleSetNetworkInterfaceId struct {
 	SubscriptionId             string
-	ResourceGroup              string
+	ResourceGroupName          string
 	VirtualMachineScaleSetName string
 	VirtualMachineIndex        string
 	NetworkInterfaceName       string
 }
 
 // NewVirtualMachineScaleSetNetworkInterfaceID returns a new VirtualMachineScaleSetNetworkInterfaceId struct
-func NewVirtualMachineScaleSetNetworkInterfaceID(subscriptionId string, resourceGroup string, virtualMachineScaleSetName string, virtualMachineIndex string, networkInterfaceName string) VirtualMachineScaleSetNetworkInterfaceId {
+func NewVirtualMachineScaleSetNetworkInterfaceID(subscriptionId string, resourceGroupName string, virtualMachineScaleSetName string, virtualMachineIndex string, networkInterfaceName string) VirtualMachineScaleSetNetworkInterfaceId {
 	return VirtualMachineScaleSetNetworkInterfaceId{
 		SubscriptionId:             subscriptionId,
-		ResourceGroup:              resourceGroup,
+		ResourceGroupName:          resourceGroupName,
 		VirtualMachineScaleSetName: virtualMachineScaleSetName,
 		VirtualMachineIndex:        virtualMachineIndex,
 		NetworkInterfaceName:       networkInterfaceName,
@@ -44,8 +44,8 @@ func ParseVirtualMachineScaleSetNetworkInterfaceID(input string) (*VirtualMachin
 		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
 	}
 
-	if id.ResourceGroup, ok = parsed.Parsed["resourceGroup"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroup' was not found in the resource id %q", input)
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
 	}
 
 	if id.VirtualMachineScaleSetName, ok = parsed.Parsed["virtualMachineScaleSetName"]; !ok {
@@ -79,8 +79,8 @@ func ParseVirtualMachineScaleSetNetworkInterfaceIDInsensitively(input string) (*
 		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
 	}
 
-	if id.ResourceGroup, ok = parsed.Parsed["resourceGroup"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroup' was not found in the resource id %q", input)
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
 	}
 
 	if id.VirtualMachineScaleSetName, ok = parsed.Parsed["virtualMachineScaleSetName"]; !ok {
@@ -116,7 +116,7 @@ func ValidateVirtualMachineScaleSetNetworkInterfaceID(input interface{}, key str
 // ID returns the formatted Virtual Machine Scale Set Network Interface ID
 func (id VirtualMachineScaleSetNetworkInterfaceId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachineScaleSets/%s/virtualMachines/%s/networkInterfaces/%s"
-	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.VirtualMachineScaleSetName, id.VirtualMachineIndex, id.NetworkInterfaceName)
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.VirtualMachineScaleSetName, id.VirtualMachineIndex, id.NetworkInterfaceName)
 }
 
 // Segments returns a slice of Resource ID Segments which comprise this Virtual Machine Scale Set Network Interface ID
@@ -125,7 +125,7 @@ func (id VirtualMachineScaleSetNetworkInterfaceId) Segments() []resourceids.Segm
 		resourceids.StaticSegment("subscriptions", "subscriptions", "subscriptions"),
 		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
 		resourceids.StaticSegment("resourceGroups", "resourceGroups", "resourceGroups"),
-		resourceids.ResourceGroupSegment("resourceGroup", "example-resource-group"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
 		resourceids.StaticSegment("providers", "providers", "providers"),
 		resourceids.ResourceProviderSegment("resourceProvider", "Microsoft.Compute", "Microsoft.Compute"),
 		resourceids.StaticSegment("virtualMachineScaleSets", "virtualMachineScaleSets", "virtualMachineScaleSets"),
@@ -141,7 +141,7 @@ func (id VirtualMachineScaleSetNetworkInterfaceId) Segments() []resourceids.Segm
 func (id VirtualMachineScaleSetNetworkInterfaceId) String() string {
 	components := []string{
 		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
-		fmt.Sprintf("Resource Group: %q", id.ResourceGroup),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
 		fmt.Sprintf("Virtual Machine Scale Set Name: %q", id.VirtualMachineScaleSetName),
 		fmt.Sprintf("Virtual Machine Index: %q", id.VirtualMachineIndex),
 		fmt.Sprintf("Network Interface Name: %q", id.NetworkInterfaceName),

--- a/resourcemanager/commonids/virtual_machine_scale_set_network_interface_test.go
+++ b/resourcemanager/commonids/virtual_machine_scale_set_network_interface_test.go
@@ -15,8 +15,8 @@ func TestNewVirtualMachineScaleSetNetworkInterfaceID(t *testing.T) {
 		t.Fatalf("Expected %q but got %q for Segment 'SubscriptionId'", id.SubscriptionId, "12345678-1234-9876-4563-123456789012")
 	}
 
-	if id.ResourceGroup != "example-resource-group" {
-		t.Fatalf("Expected %q but got %q for Segment 'ResourceGroup'", id.ResourceGroup, "example-resource-group")
+	if id.ResourceGroupName != "example-resource-group" {
+		t.Fatalf("Expected %q but got %q for Segment 'ResourceGroupName'", id.ResourceGroupName, "example-resource-group")
 	}
 
 	if id.VirtualMachineScaleSetName != "virtualMachineScaleSetValue" {
@@ -111,7 +111,7 @@ func TestParseVirtualMachineScaleSetNetworkInterfaceID(t *testing.T) {
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Compute/virtualMachineScaleSets/virtualMachineScaleSetValue/virtualMachines/virtualMachineIndexValue/networkInterfaces/networkInterfaceValue",
 			Expected: &VirtualMachineScaleSetNetworkInterfaceId{
 				SubscriptionId:             "12345678-1234-9876-4563-123456789012",
-				ResourceGroup:              "example-resource-group",
+				ResourceGroupName:          "example-resource-group",
 				VirtualMachineScaleSetName: "virtualMachineScaleSetValue",
 				VirtualMachineIndex:        "virtualMachineIndexValue",
 				NetworkInterfaceName:       "networkInterfaceValue",
@@ -142,8 +142,8 @@ func TestParseVirtualMachineScaleSetNetworkInterfaceID(t *testing.T) {
 			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
 		}
 
-		if actual.ResourceGroup != v.Expected.ResourceGroup {
-			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
 		}
 
 		if actual.VirtualMachineScaleSetName != v.Expected.VirtualMachineScaleSetName {
@@ -287,7 +287,7 @@ func TestParseVirtualMachineScaleSetNetworkInterfaceIDInsensitively(t *testing.T
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Compute/virtualMachineScaleSets/virtualMachineScaleSetValue/virtualMachines/virtualMachineIndexValue/networkInterfaces/networkInterfaceValue",
 			Expected: &VirtualMachineScaleSetNetworkInterfaceId{
 				SubscriptionId:             "12345678-1234-9876-4563-123456789012",
-				ResourceGroup:              "example-resource-group",
+				ResourceGroupName:          "example-resource-group",
 				VirtualMachineScaleSetName: "virtualMachineScaleSetValue",
 				VirtualMachineIndex:        "virtualMachineIndexValue",
 				NetworkInterfaceName:       "networkInterfaceValue",
@@ -303,7 +303,7 @@ func TestParseVirtualMachineScaleSetNetworkInterfaceIDInsensitively(t *testing.T
 			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.cOmPuTe/vIrTuAlMaChInEsCaLeSeTs/vIrTuAlMaChInEsCaLeSeTvAlUe/vIrTuAlMaChInEs/vIrTuAlMaChInEiNdExVaLuE/nEtWoRkInTeRfAcEs/nEtWoRkInTeRfAcEvAlUe",
 			Expected: &VirtualMachineScaleSetNetworkInterfaceId{
 				SubscriptionId:             "12345678-1234-9876-4563-123456789012",
-				ResourceGroup:              "eXaMpLe-rEsOuRcE-GrOuP",
+				ResourceGroupName:          "eXaMpLe-rEsOuRcE-GrOuP",
 				VirtualMachineScaleSetName: "vIrTuAlMaChInEsCaLeSeTvAlUe",
 				VirtualMachineIndex:        "vIrTuAlMaChInEiNdExVaLuE",
 				NetworkInterfaceName:       "nEtWoRkInTeRfAcEvAlUe",
@@ -334,8 +334,8 @@ func TestParseVirtualMachineScaleSetNetworkInterfaceIDInsensitively(t *testing.T
 			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
 		}
 
-		if actual.ResourceGroup != v.Expected.ResourceGroup {
-			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
 		}
 
 		if actual.VirtualMachineScaleSetName != v.Expected.VirtualMachineScaleSetName {

--- a/resourcemanager/commonids/virtual_machine_scale_set_public_ip_address.go
+++ b/resourcemanager/commonids/virtual_machine_scale_set_public_ip_address.go
@@ -12,7 +12,7 @@ var _ resourceids.ResourceId = VirtualMachineScaleSetPublicIPAddressId{}
 // VirtualMachineScaleSetPublicIPAddressId is a struct representing the Resource ID for a Virtual Machine Scale Set Public I P Address
 type VirtualMachineScaleSetPublicIPAddressId struct {
 	SubscriptionId             string
-	ResourceGroup              string
+	ResourceGroupName          string
 	VirtualMachineScaleSetName string
 	VirtualMachineIndex        string
 	NetworkInterfaceName       string
@@ -21,10 +21,10 @@ type VirtualMachineScaleSetPublicIPAddressId struct {
 }
 
 // NewVirtualMachineScaleSetPublicIPAddressID returns a new VirtualMachineScaleSetPublicIPAddressId struct
-func NewVirtualMachineScaleSetPublicIPAddressID(subscriptionId string, resourceGroup string, virtualMachineScaleSetName string, virtualMachineIndex string, networkInterfaceName string, ipConfigurationName string, publicIpAddressName string) VirtualMachineScaleSetPublicIPAddressId {
+func NewVirtualMachineScaleSetPublicIPAddressID(subscriptionId string, resourceGroupName string, virtualMachineScaleSetName string, virtualMachineIndex string, networkInterfaceName string, ipConfigurationName string, publicIpAddressName string) VirtualMachineScaleSetPublicIPAddressId {
 	return VirtualMachineScaleSetPublicIPAddressId{
 		SubscriptionId:             subscriptionId,
-		ResourceGroup:              resourceGroup,
+		ResourceGroupName:          resourceGroupName,
 		VirtualMachineScaleSetName: virtualMachineScaleSetName,
 		VirtualMachineIndex:        virtualMachineIndex,
 		NetworkInterfaceName:       networkInterfaceName,
@@ -48,8 +48,8 @@ func ParseVirtualMachineScaleSetPublicIPAddressID(input string) (*VirtualMachine
 		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
 	}
 
-	if id.ResourceGroup, ok = parsed.Parsed["resourceGroup"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroup' was not found in the resource id %q", input)
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
 	}
 
 	if id.VirtualMachineScaleSetName, ok = parsed.Parsed["virtualMachineScaleSetName"]; !ok {
@@ -91,8 +91,8 @@ func ParseVirtualMachineScaleSetPublicIPAddressIDInsensitively(input string) (*V
 		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
 	}
 
-	if id.ResourceGroup, ok = parsed.Parsed["resourceGroup"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroup' was not found in the resource id %q", input)
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
 	}
 
 	if id.VirtualMachineScaleSetName, ok = parsed.Parsed["virtualMachineScaleSetName"]; !ok {
@@ -133,10 +133,10 @@ func ValidateVirtualMachineScaleSetPublicIPAddressID(input interface{}, key stri
 	return
 }
 
-// ID returns the formatted Virtual Machine Scale Set Public I P Address ID
+// ID returns the formatted Virtual Machine Scale Set Public IP Address ID
 func (id VirtualMachineScaleSetPublicIPAddressId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachineScaleSets/%s/virtualMachines/%s/networkInterfaces/%s/ipConfigurations/%s/publicIPAddresses/%s"
-	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.VirtualMachineScaleSetName, id.VirtualMachineIndex, id.NetworkInterfaceName, id.IpConfigurationName, id.PublicIpAddressName)
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.VirtualMachineScaleSetName, id.VirtualMachineIndex, id.NetworkInterfaceName, id.IpConfigurationName, id.PublicIpAddressName)
 }
 
 // Segments returns a slice of Resource ID Segments which comprise this Virtual Machine Scale Set Public I P Address ID
@@ -145,7 +145,7 @@ func (id VirtualMachineScaleSetPublicIPAddressId) Segments() []resourceids.Segme
 		resourceids.StaticSegment("subscriptions", "subscriptions", "subscriptions"),
 		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
 		resourceids.StaticSegment("resourceGroups", "resourceGroups", "resourceGroups"),
-		resourceids.ResourceGroupSegment("resourceGroup", "example-resource-group"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
 		resourceids.StaticSegment("providers", "providers", "providers"),
 		resourceids.ResourceProviderSegment("resourceProvider", "Microsoft.Compute", "Microsoft.Compute"),
 		resourceids.StaticSegment("virtualMachineScaleSets", "virtualMachineScaleSets", "virtualMachineScaleSets"),
@@ -165,7 +165,7 @@ func (id VirtualMachineScaleSetPublicIPAddressId) Segments() []resourceids.Segme
 func (id VirtualMachineScaleSetPublicIPAddressId) String() string {
 	components := []string{
 		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
-		fmt.Sprintf("Resource Group: %q", id.ResourceGroup),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
 		fmt.Sprintf("Virtual Machine Scale Set Name: %q", id.VirtualMachineScaleSetName),
 		fmt.Sprintf("Virtual Machine Index: %q", id.VirtualMachineIndex),
 		fmt.Sprintf("Network Interface Name: %q", id.NetworkInterfaceName),

--- a/resourcemanager/commonids/virtual_machine_scale_set_public_ip_address_test.go
+++ b/resourcemanager/commonids/virtual_machine_scale_set_public_ip_address_test.go
@@ -15,8 +15,8 @@ func TestNewVirtualMachineScaleSetPublicIPAddressID(t *testing.T) {
 		t.Fatalf("Expected %q but got %q for Segment 'SubscriptionId'", id.SubscriptionId, "12345678-1234-9876-4563-123456789012")
 	}
 
-	if id.ResourceGroup != "example-resource-group" {
-		t.Fatalf("Expected %q but got %q for Segment 'ResourceGroup'", id.ResourceGroup, "example-resource-group")
+	if id.ResourceGroupName != "example-resource-group" {
+		t.Fatalf("Expected %q but got %q for Segment 'ResourceGroupName'", id.ResourceGroupName, "example-resource-group")
 	}
 
 	if id.VirtualMachineScaleSetName != "virtualMachineScaleSetValue" {
@@ -139,7 +139,7 @@ func TestParseVirtualMachineScaleSetPublicIPAddressID(t *testing.T) {
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Compute/virtualMachineScaleSets/virtualMachineScaleSetValue/virtualMachines/virtualMachineIndexValue/networkInterfaces/networkInterfaceValue/ipConfigurations/ipConfigurationValue/publicIPAddresses/publicIpAddressValue",
 			Expected: &VirtualMachineScaleSetPublicIPAddressId{
 				SubscriptionId:             "12345678-1234-9876-4563-123456789012",
-				ResourceGroup:              "example-resource-group",
+				ResourceGroupName:          "example-resource-group",
 				VirtualMachineScaleSetName: "virtualMachineScaleSetValue",
 				VirtualMachineIndex:        "virtualMachineIndexValue",
 				NetworkInterfaceName:       "networkInterfaceValue",
@@ -172,8 +172,8 @@ func TestParseVirtualMachineScaleSetPublicIPAddressID(t *testing.T) {
 			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
 		}
 
-		if actual.ResourceGroup != v.Expected.ResourceGroup {
-			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
 		}
 
 		if actual.VirtualMachineScaleSetName != v.Expected.VirtualMachineScaleSetName {
@@ -365,7 +365,7 @@ func TestParseVirtualMachineScaleSetPublicIPAddressIDInsensitively(t *testing.T)
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Compute/virtualMachineScaleSets/virtualMachineScaleSetValue/virtualMachines/virtualMachineIndexValue/networkInterfaces/networkInterfaceValue/ipConfigurations/ipConfigurationValue/publicIPAddresses/publicIpAddressValue",
 			Expected: &VirtualMachineScaleSetPublicIPAddressId{
 				SubscriptionId:             "12345678-1234-9876-4563-123456789012",
-				ResourceGroup:              "example-resource-group",
+				ResourceGroupName:          "example-resource-group",
 				VirtualMachineScaleSetName: "virtualMachineScaleSetValue",
 				VirtualMachineIndex:        "virtualMachineIndexValue",
 				NetworkInterfaceName:       "networkInterfaceValue",
@@ -383,7 +383,7 @@ func TestParseVirtualMachineScaleSetPublicIPAddressIDInsensitively(t *testing.T)
 			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.cOmPuTe/vIrTuAlMaChInEsCaLeSeTs/vIrTuAlMaChInEsCaLeSeTvAlUe/vIrTuAlMaChInEs/vIrTuAlMaChInEiNdExVaLuE/nEtWoRkInTeRfAcEs/nEtWoRkInTeRfAcEvAlUe/iPcOnFiGuRaTiOnS/iPcOnFiGuRaTiOnVaLuE/pUbLiCiPaDdReSsEs/pUbLiCiPaDdReSsVaLuE",
 			Expected: &VirtualMachineScaleSetPublicIPAddressId{
 				SubscriptionId:             "12345678-1234-9876-4563-123456789012",
-				ResourceGroup:              "eXaMpLe-rEsOuRcE-GrOuP",
+				ResourceGroupName:          "eXaMpLe-rEsOuRcE-GrOuP",
 				VirtualMachineScaleSetName: "vIrTuAlMaChInEsCaLeSeTvAlUe",
 				VirtualMachineIndex:        "vIrTuAlMaChInEiNdExVaLuE",
 				NetworkInterfaceName:       "nEtWoRkInTeRfAcEvAlUe",
@@ -416,8 +416,8 @@ func TestParseVirtualMachineScaleSetPublicIPAddressIDInsensitively(t *testing.T)
 			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
 		}
 
-		if actual.ResourceGroup != v.Expected.ResourceGroup {
-			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
 		}
 
 		if actual.VirtualMachineScaleSetName != v.Expected.VirtualMachineScaleSetName {

--- a/resourcemanager/commonids/virtual_router_peering.go
+++ b/resourcemanager/commonids/virtual_router_peering.go
@@ -12,16 +12,16 @@ var _ resourceids.ResourceId = VirtualRouterPeeringId{}
 // VirtualRouterPeeringId is a struct representing the Resource ID for a Virtual Router Peering
 type VirtualRouterPeeringId struct {
 	SubscriptionId    string
-	ResourceGroup     string
+	ResourceGroupName string
 	VirtualRouterName string
 	PeeringName       string
 }
 
 // NewVirtualRouterPeeringID returns a new VirtualRouterPeeringId struct
-func NewVirtualRouterPeeringID(subscriptionId string, resourceGroup string, virtualRouterName string, peeringName string) VirtualRouterPeeringId {
+func NewVirtualRouterPeeringID(subscriptionId string, resourceGroupName string, virtualRouterName string, peeringName string) VirtualRouterPeeringId {
 	return VirtualRouterPeeringId{
 		SubscriptionId:    subscriptionId,
-		ResourceGroup:     resourceGroup,
+		ResourceGroupName: resourceGroupName,
 		VirtualRouterName: virtualRouterName,
 		PeeringName:       peeringName,
 	}
@@ -42,8 +42,8 @@ func ParseVirtualRouterPeeringID(input string) (*VirtualRouterPeeringId, error) 
 		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
 	}
 
-	if id.ResourceGroup, ok = parsed.Parsed["resourceGroup"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroup' was not found in the resource id %q", input)
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
 	}
 
 	if id.VirtualRouterName, ok = parsed.Parsed["virtualRouterName"]; !ok {
@@ -73,8 +73,8 @@ func ParseVirtualRouterPeeringIDInsensitively(input string) (*VirtualRouterPeeri
 		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
 	}
 
-	if id.ResourceGroup, ok = parsed.Parsed["resourceGroup"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroup' was not found in the resource id %q", input)
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
 	}
 
 	if id.VirtualRouterName, ok = parsed.Parsed["virtualRouterName"]; !ok {
@@ -106,7 +106,7 @@ func ValidateVirtualRouterPeeringID(input interface{}, key string) (warnings []s
 // ID returns the formatted Virtual Router Peering ID
 func (id VirtualRouterPeeringId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualRouters/%s/peerings/%s"
-	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.VirtualRouterName, id.PeeringName)
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.VirtualRouterName, id.PeeringName)
 }
 
 // Segments returns a slice of Resource ID Segments which comprise this Virtual Router Peering ID
@@ -115,7 +115,7 @@ func (id VirtualRouterPeeringId) Segments() []resourceids.Segment {
 		resourceids.StaticSegment("subscriptions", "subscriptions", "subscriptions"),
 		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
 		resourceids.StaticSegment("resourceGroups", "resourceGroups", "resourceGroups"),
-		resourceids.ResourceGroupSegment("resourceGroup", "example-resource-group"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
 		resourceids.StaticSegment("providers", "providers", "providers"),
 		resourceids.ResourceProviderSegment("resourceProvider", "Microsoft.Network", "Microsoft.Network"),
 		resourceids.StaticSegment("virtualRouters", "virtualRouters", "virtualRouters"),
@@ -129,7 +129,7 @@ func (id VirtualRouterPeeringId) Segments() []resourceids.Segment {
 func (id VirtualRouterPeeringId) String() string {
 	components := []string{
 		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
-		fmt.Sprintf("Resource Group: %q", id.ResourceGroup),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
 		fmt.Sprintf("Virtual Router Name: %q", id.VirtualRouterName),
 		fmt.Sprintf("Peering Name: %q", id.PeeringName),
 	}

--- a/resourcemanager/commonids/virtual_router_peering_test.go
+++ b/resourcemanager/commonids/virtual_router_peering_test.go
@@ -15,8 +15,8 @@ func TestNewVirtualRouterPeeringID(t *testing.T) {
 		t.Fatalf("Expected %q but got %q for Segment 'SubscriptionId'", id.SubscriptionId, "12345678-1234-9876-4563-123456789012")
 	}
 
-	if id.ResourceGroup != "example-resource-group" {
-		t.Fatalf("Expected %q but got %q for Segment 'ResourceGroup'", id.ResourceGroup, "example-resource-group")
+	if id.ResourceGroupName != "example-resource-group" {
+		t.Fatalf("Expected %q but got %q for Segment 'ResourceGroupName'", id.ResourceGroupName, "example-resource-group")
 	}
 
 	if id.VirtualRouterName != "virtualRouterValue" {
@@ -97,7 +97,7 @@ func TestParseVirtualRouterPeeringID(t *testing.T) {
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Network/virtualRouters/virtualRouterValue/peerings/peeringValue",
 			Expected: &VirtualRouterPeeringId{
 				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
-				ResourceGroup:     "example-resource-group",
+				ResourceGroupName: "example-resource-group",
 				VirtualRouterName: "virtualRouterValue",
 				PeeringName:       "peeringValue",
 			},
@@ -127,8 +127,8 @@ func TestParseVirtualRouterPeeringID(t *testing.T) {
 			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
 		}
 
-		if actual.ResourceGroup != v.Expected.ResourceGroup {
-			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
 		}
 
 		if actual.VirtualRouterName != v.Expected.VirtualRouterName {
@@ -248,7 +248,7 @@ func TestParseVirtualRouterPeeringIDInsensitively(t *testing.T) {
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Network/virtualRouters/virtualRouterValue/peerings/peeringValue",
 			Expected: &VirtualRouterPeeringId{
 				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
-				ResourceGroup:     "example-resource-group",
+				ResourceGroupName: "example-resource-group",
 				VirtualRouterName: "virtualRouterValue",
 				PeeringName:       "peeringValue",
 			},
@@ -263,7 +263,7 @@ func TestParseVirtualRouterPeeringIDInsensitively(t *testing.T) {
 			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.nEtWoRk/vIrTuAlRoUtErS/vIrTuAlRoUtErVaLuE/pEeRiNgS/pEeRiNgVaLuE",
 			Expected: &VirtualRouterPeeringId{
 				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
-				ResourceGroup:     "eXaMpLe-rEsOuRcE-GrOuP",
+				ResourceGroupName: "eXaMpLe-rEsOuRcE-GrOuP",
 				VirtualRouterName: "vIrTuAlRoUtErVaLuE",
 				PeeringName:       "pEeRiNgVaLuE",
 			},
@@ -293,8 +293,8 @@ func TestParseVirtualRouterPeeringIDInsensitively(t *testing.T) {
 			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
 		}
 
-		if actual.ResourceGroup != v.Expected.ResourceGroup {
-			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
 		}
 
 		if actual.VirtualRouterName != v.Expected.VirtualRouterName {

--- a/resourcemanager/commonids/virtual_wan_p2s_vpn_gateway.go
+++ b/resourcemanager/commonids/virtual_wan_p2s_vpn_gateway.go
@@ -9,19 +9,19 @@ import (
 
 var _ resourceids.ResourceId = VirtualWANP2SVPNGatewayId{}
 
-// VirtualWANP2SVPNGatewayId is a struct representing the Resource ID for a Virtual W A N P 2 S V P N Gateway
+// VirtualWANP2SVPNGatewayId is a struct representing the Resource ID for a Virtual WAN P2S VPN Gateway
 type VirtualWANP2SVPNGatewayId struct {
-	SubscriptionId string
-	ResourceGroup  string
-	GatewayName    string
+	SubscriptionId    string
+	ResourceGroupName string
+	GatewayName       string
 }
 
 // NewVirtualWANP2SVPNGatewayID returns a new VirtualWANP2SVPNGatewayId struct
-func NewVirtualWANP2SVPNGatewayID(subscriptionId string, resourceGroup string, gatewayName string) VirtualWANP2SVPNGatewayId {
+func NewVirtualWANP2SVPNGatewayID(subscriptionId string, resourceGroupName string, gatewayName string) VirtualWANP2SVPNGatewayId {
 	return VirtualWANP2SVPNGatewayId{
-		SubscriptionId: subscriptionId,
-		ResourceGroup:  resourceGroup,
-		GatewayName:    gatewayName,
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		GatewayName:       gatewayName,
 	}
 }
 
@@ -40,8 +40,8 @@ func ParseVirtualWANP2SVPNGatewayID(input string) (*VirtualWANP2SVPNGatewayId, e
 		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
 	}
 
-	if id.ResourceGroup, ok = parsed.Parsed["resourceGroup"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroup' was not found in the resource id %q", input)
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
 	}
 
 	if id.GatewayName, ok = parsed.Parsed["gatewayName"]; !ok {
@@ -67,8 +67,8 @@ func ParseVirtualWANP2SVPNGatewayIDInsensitively(input string) (*VirtualWANP2SVP
 		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
 	}
 
-	if id.ResourceGroup, ok = parsed.Parsed["resourceGroup"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroup' was not found in the resource id %q", input)
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
 	}
 
 	if id.GatewayName, ok = parsed.Parsed["gatewayName"]; !ok {
@@ -78,7 +78,7 @@ func ParseVirtualWANP2SVPNGatewayIDInsensitively(input string) (*VirtualWANP2SVP
 	return &id, nil
 }
 
-// ValidateVirtualWANP2SVPNGatewayID checks that 'input' can be parsed as a Virtual W A N P 2 S V P N Gateway ID
+// ValidateVirtualWANP2SVPNGatewayID checks that 'input' can be parsed as a Virtual WAN P2S VPN Gateway ID
 func ValidateVirtualWANP2SVPNGatewayID(input interface{}, key string) (warnings []string, errors []error) {
 	v, ok := input.(string)
 	if !ok {
@@ -93,19 +93,19 @@ func ValidateVirtualWANP2SVPNGatewayID(input interface{}, key string) (warnings 
 	return
 }
 
-// ID returns the formatted Virtual W A N P 2 S V P N Gateway ID
+// ID returns the formatted Virtual WAN P2S VPN Gateway ID
 func (id VirtualWANP2SVPNGatewayId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/p2sVpnGateways/%s"
-	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.GatewayName)
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.GatewayName)
 }
 
-// Segments returns a slice of Resource ID Segments which comprise this Virtual W A N P 2 S V P N Gateway ID
+// Segments returns a slice of Resource ID Segments which comprise this Virtual WAN P2S VPN Gateway ID
 func (id VirtualWANP2SVPNGatewayId) Segments() []resourceids.Segment {
 	return []resourceids.Segment{
 		resourceids.StaticSegment("subscriptions", "subscriptions", "subscriptions"),
 		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
 		resourceids.StaticSegment("resourceGroups", "resourceGroups", "resourceGroups"),
-		resourceids.ResourceGroupSegment("resourceGroup", "example-resource-group"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
 		resourceids.StaticSegment("providers", "providers", "providers"),
 		resourceids.ResourceProviderSegment("resourceProvider", "Microsoft.Network", "Microsoft.Network"),
 		resourceids.StaticSegment("p2sVpnGateways", "p2sVpnGateways", "p2sVpnGateways"),
@@ -113,11 +113,11 @@ func (id VirtualWANP2SVPNGatewayId) Segments() []resourceids.Segment {
 	}
 }
 
-// String returns a human-readable description of this Virtual W A N P 2 S V P N Gateway ID
+// String returns a human-readable description of this Virtual WAN P2S VPN Gateway ID
 func (id VirtualWANP2SVPNGatewayId) String() string {
 	components := []string{
 		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
-		fmt.Sprintf("Resource Group: %q", id.ResourceGroup),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
 		fmt.Sprintf("Gateway Name: %q", id.GatewayName),
 	}
 	return fmt.Sprintf("Virtual WAN P2S VPN Gateway (%s)", strings.Join(components, "\n"))

--- a/resourcemanager/commonids/vpn_connection.go
+++ b/resourcemanager/commonids/vpn_connection.go
@@ -11,19 +11,19 @@ var _ resourceids.ResourceId = VPNConnectionId{}
 
 // VPNConnectionId is a struct representing the Resource ID for a V P N Connection
 type VPNConnectionId struct {
-	SubscriptionId string
-	ResourceGroup  string
-	GatewayName    string
-	ConnectionName string
+	SubscriptionId    string
+	ResourceGroupName string
+	GatewayName       string
+	ConnectionName    string
 }
 
 // NewVPNConnectionID returns a new VPNConnectionId struct
-func NewVPNConnectionID(subscriptionId string, resourceGroup string, gatewayName string, connectionName string) VPNConnectionId {
+func NewVPNConnectionID(subscriptionId string, resourceGroupName string, gatewayName string, connectionName string) VPNConnectionId {
 	return VPNConnectionId{
-		SubscriptionId: subscriptionId,
-		ResourceGroup:  resourceGroup,
-		GatewayName:    gatewayName,
-		ConnectionName: connectionName,
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		GatewayName:       gatewayName,
+		ConnectionName:    connectionName,
 	}
 }
 
@@ -42,8 +42,8 @@ func ParseVPNConnectionID(input string) (*VPNConnectionId, error) {
 		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
 	}
 
-	if id.ResourceGroup, ok = parsed.Parsed["resourceGroup"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroup' was not found in the resource id %q", input)
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
 	}
 
 	if id.GatewayName, ok = parsed.Parsed["gatewayName"]; !ok {
@@ -73,8 +73,8 @@ func ParseVPNConnectionIDInsensitively(input string) (*VPNConnectionId, error) {
 		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
 	}
 
-	if id.ResourceGroup, ok = parsed.Parsed["resourceGroup"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroup' was not found in the resource id %q", input)
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
 	}
 
 	if id.GatewayName, ok = parsed.Parsed["gatewayName"]; !ok {
@@ -106,7 +106,7 @@ func ValidateVPNConnectionID(input interface{}, key string) (warnings []string, 
 // ID returns the formatted V P N Connection ID
 func (id VPNConnectionId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/vpnGateways/%s/vpnConnections/%s"
-	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.GatewayName, id.ConnectionName)
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.GatewayName, id.ConnectionName)
 }
 
 // Segments returns a slice of Resource ID Segments which comprise this V P N Connection ID
@@ -115,7 +115,7 @@ func (id VPNConnectionId) Segments() []resourceids.Segment {
 		resourceids.StaticSegment("subscriptions", "subscriptions", "subscriptions"),
 		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
 		resourceids.StaticSegment("resourceGroups", "resourceGroups", "resourceGroups"),
-		resourceids.ResourceGroupSegment("resourceGroup", "example-resource-group"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
 		resourceids.StaticSegment("providers", "providers", "providers"),
 		resourceids.ResourceProviderSegment("resourceProvider", "Microsoft.Network", "Microsoft.Network"),
 		resourceids.StaticSegment("vpnGateways", "vpnGateways", "vpnGateways"),
@@ -129,9 +129,9 @@ func (id VPNConnectionId) Segments() []resourceids.Segment {
 func (id VPNConnectionId) String() string {
 	components := []string{
 		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
-		fmt.Sprintf("Resource Group: %q", id.ResourceGroup),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
 		fmt.Sprintf("Gateway Name: %q", id.GatewayName),
 		fmt.Sprintf("Connection Name: %q", id.ConnectionName),
 	}
-	return fmt.Sprintf("V P N Connection (%s)", strings.Join(components, "\n"))
+	return fmt.Sprintf("VPN Connection (%s)", strings.Join(components, "\n"))
 }

--- a/resourcemanager/commonids/vpn_connection_test.go
+++ b/resourcemanager/commonids/vpn_connection_test.go
@@ -15,8 +15,8 @@ func TestNewVPNConnectionID(t *testing.T) {
 		t.Fatalf("Expected %q but got %q for Segment 'SubscriptionId'", id.SubscriptionId, "12345678-1234-9876-4563-123456789012")
 	}
 
-	if id.ResourceGroup != "example-resource-group" {
-		t.Fatalf("Expected %q but got %q for Segment 'ResourceGroup'", id.ResourceGroup, "example-resource-group")
+	if id.ResourceGroupName != "example-resource-group" {
+		t.Fatalf("Expected %q but got %q for Segment 'ResourceGroupName'", id.ResourceGroupName, "example-resource-group")
 	}
 
 	if id.GatewayName != "gatewayValue" {
@@ -96,10 +96,10 @@ func TestParseVPNConnectionID(t *testing.T) {
 			// Valid URI
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Network/vpnGateways/gatewayValue/vpnConnections/connectionValue",
 			Expected: &VPNConnectionId{
-				SubscriptionId: "12345678-1234-9876-4563-123456789012",
-				ResourceGroup:  "example-resource-group",
-				GatewayName:    "gatewayValue",
-				ConnectionName: "connectionValue",
+				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName: "example-resource-group",
+				GatewayName:       "gatewayValue",
+				ConnectionName:    "connectionValue",
 			},
 		},
 		{
@@ -127,8 +127,8 @@ func TestParseVPNConnectionID(t *testing.T) {
 			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
 		}
 
-		if actual.ResourceGroup != v.Expected.ResourceGroup {
-			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
 		}
 
 		if actual.GatewayName != v.Expected.GatewayName {
@@ -247,10 +247,10 @@ func TestParseVPNConnectionIDInsensitively(t *testing.T) {
 			// Valid URI
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Network/vpnGateways/gatewayValue/vpnConnections/connectionValue",
 			Expected: &VPNConnectionId{
-				SubscriptionId: "12345678-1234-9876-4563-123456789012",
-				ResourceGroup:  "example-resource-group",
-				GatewayName:    "gatewayValue",
-				ConnectionName: "connectionValue",
+				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName: "example-resource-group",
+				GatewayName:       "gatewayValue",
+				ConnectionName:    "connectionValue",
 			},
 		},
 		{
@@ -262,10 +262,10 @@ func TestParseVPNConnectionIDInsensitively(t *testing.T) {
 			// Valid URI (mIxEd CaSe since this is insensitive)
 			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.nEtWoRk/vPnGaTeWaYs/gAtEwAyVaLuE/vPnCoNnEcTiOnS/cOnNeCtIoNvAlUe",
 			Expected: &VPNConnectionId{
-				SubscriptionId: "12345678-1234-9876-4563-123456789012",
-				ResourceGroup:  "eXaMpLe-rEsOuRcE-GrOuP",
-				GatewayName:    "gAtEwAyVaLuE",
-				ConnectionName: "cOnNeCtIoNvAlUe",
+				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName: "eXaMpLe-rEsOuRcE-GrOuP",
+				GatewayName:       "gAtEwAyVaLuE",
+				ConnectionName:    "cOnNeCtIoNvAlUe",
 			},
 		},
 		{
@@ -293,8 +293,8 @@ func TestParseVPNConnectionIDInsensitively(t *testing.T) {
 			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
 		}
 
-		if actual.ResourceGroup != v.Expected.ResourceGroup {
-			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		if actual.ResourceGroupName != v.Expected.ResourceGroupName {
+			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
 		}
 
 		if actual.GatewayName != v.Expected.GatewayName {


### PR DESCRIPTION
These should be `resourceGroupName` rather than `resourceGroup`