### PR TITLE
resourcemanager/zones: adding the Untyped Expand/Flatten functions

### DIFF
--- a/resourcemanager/zones/expand.go
+++ b/resourcemanager/zones/expand.go
@@ -1,6 +1,18 @@
 package zones
 
-func Expand(input []interface{}) []string {
+func Expand(input []string) Schema {
+	out := Schema{}
+
+	if input != nil {
+		for _, v := range input {
+			out = append(out, v)
+		}
+	}
+
+	return out
+}
+
+func ExpandUntyped(input []interface{}) []string {
 	out := make([]string, 0)
 
 	if input != nil {

--- a/resourcemanager/zones/flatten.go
+++ b/resourcemanager/zones/flatten.go
@@ -1,6 +1,18 @@
 package zones
 
-func Flatten(input *[]string) []interface{} {
+func Flatten(input *Schema) []string {
+	out := make([]string, 0)
+
+	if input != nil {
+		for _, v := range *input {
+			out = append(out, v)
+		}
+	}
+
+	return out
+}
+
+func FlattenUntyped(input *[]string) []interface{} {
 	out := make([]interface{}, 0)
 
 	if input != nil {


### PR DESCRIPTION
These allow the `.Expand` and `.Flatten` functions to become Typed by default