### PR TITLE
`auth` - support authentication with a bear token string

### DIFF
--- a/authentication/auth_method_azure_bear_token.go
+++ b/authentication/auth_method_azure_bear_token.go
@@ -1,0 +1,64 @@
+package authentication
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/hashicorp/go-multierror"
+	"github.com/manicminer/hamilton/environments"
+)
+
+type azureBearTokenAuth struct {
+	bearToken string
+}
+
+func (a azureBearTokenAuth) build(b Builder) (authMethod, error) {
+	auth := azureBearTokenAuth{
+		bearToken: b.BearToken,
+	}
+
+	return auth, nil
+}
+
+func (a azureBearTokenAuth) isApplicable(b Builder) bool {
+	return b.BearToken != ""
+}
+
+func (a azureBearTokenAuth) getADALToken(_ context.Context, _ autorest.Sender, oauthConfig *OAuthConfig, endpoint string) (autorest.Authorizer, error) {
+	auth := autorest.NewBearerAuthorizer(&BearTokenProvider{
+		token: a.bearToken,
+	})
+	return auth, nil
+}
+
+func (a azureBearTokenAuth) getMSALToken(ctx context.Context, _ environments.Api, sender autorest.Sender, oauthConfig *OAuthConfig, endpoint string) (autorest.Authorizer, error) {
+	return a.getADALToken(ctx, sender, oauthConfig, endpoint)
+}
+
+func (a azureBearTokenAuth) name() string {
+	return "Bear Token"
+}
+
+func (a azureBearTokenAuth) populateConfig(c *Config) error {
+	return nil
+}
+
+func (a azureBearTokenAuth) validate() error {
+	var err *multierror.Error
+
+	if a.bearToken == "" {
+		err = multierror.Append(err, fmt.Errorf("A Bear Token must be configured"))
+	}
+
+	return err.ErrorOrNil()
+}
+
+type BearTokenProvider struct {
+	token string
+}
+
+// OAuthToken implements the OAuthTokenProvider interface.  It returns the current access token.
+func (btp *BearTokenProvider) OAuthToken() string {
+	return btp.token
+}

--- a/authentication/auth_method_azure_bear_token_test.go
+++ b/authentication/auth_method_azure_bear_token_test.go
@@ -1,0 +1,93 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package authentication
+
+import "testing"
+
+func TestAzureBearToken_builder(t *testing.T) {
+	builder := Builder{
+		BearToken: "token",
+	}
+
+	method, err := azureBearTokenAuth{}.build(builder)
+	if err != nil {
+		t.Fatalf("Error building Azure Bear Token Auth: %+v", err)
+	}
+
+	authMethod := method.(azureBearTokenAuth)
+	if builder.BearToken != authMethod.bearToken {
+		t.Fatalf("Expected bear token to be %q but got %q", builder.BearToken, authMethod.bearToken)
+	}
+}
+
+func TestAzureBearToken_isApplicable(t *testing.T) {
+	cases := []struct {
+		Description string
+		Builder     Builder
+		Valid       bool
+	}{
+		{
+			Description: "Empty Bear Token",
+			Builder:     Builder{},
+			Valid:       false,
+		},
+		{
+			Description: "Valid Bear Token",
+			Builder: Builder{
+				BearToken: "token",
+			},
+			Valid: true,
+		},
+	}
+
+	for _, v := range cases {
+		applicable := azureBearTokenAuth{}.isApplicable(v.Builder)
+		if v.Valid != applicable {
+			t.Fatalf("Expected %q to be %t but got %t", v.Description, v.Valid, applicable)
+		}
+	}
+}
+
+func TestAzureBearToken_populateConfig(t *testing.T) {
+	config := &Config{}
+	err := azureBearTokenAuth{}.populateConfig(config)
+	if err != nil {
+		t.Fatalf("Error populating config: %s", err)
+	}
+
+	// nothing to check since it's not doing anything
+}
+
+func TestAzureBearToken_validate(t *testing.T) {
+	cases := []struct {
+		Description string
+		Config      azureBearTokenAuth
+		ExpectError bool
+	}{
+		{
+			Description: "Empty Bear Token",
+			Config:      azureBearTokenAuth{},
+			ExpectError: true,
+		},
+		{
+			Description: "Valid Bear Token",
+			Config: azureBearTokenAuth{
+				bearToken: "token",
+			},
+			ExpectError: false,
+		},
+	}
+
+	for _, v := range cases {
+		err := v.Config.validate()
+
+		if v.ExpectError && err == nil {
+			t.Fatalf("Expected an error for %q: didn't get one", v.Description)
+		}
+
+		if !v.ExpectError && err != nil {
+			t.Fatalf("Expected there to be no error for %q - but got: %v", v.Description, err)
+		}
+	}
+}

--- a/authentication/builder.go
+++ b/authentication/builder.go
@@ -54,6 +54,9 @@ type Builder struct {
 	IDTokenRequestURL   string
 	IDTokenRequestToken string
 
+	//Bear Token Auth
+	BearToken string
+
 	// Beta opt-in for Microsoft Graph
 	UseMicrosoftGraph bool
 }
@@ -82,6 +85,7 @@ func (b Builder) Build() (*Config, error) {
 		managedServiceIdentityAuth{},
 		azureCliTokenMultiTenantAuth{},
 		azureCliTokenAuth{},
+		azureBearTokenAuth{},
 	}
 
 	for _, method := range supportedAuthenticationMethods {


### PR DESCRIPTION
We have a requirement of authenticating with a bear token string when using AzureRM Provider.