### PR TITLE
resourcemanager/commonids: refactoring User Assigned Identity ID to use the updated segment name

### DIFF
--- a/resourcemanager/commonids/user_assigned_identity.go
+++ b/resourcemanager/commonids/user_assigned_identity.go
@@ -14,17 +14,17 @@ var _ resourceids.ResourceId = UserAssignedIdentityId{}
 
 // UserAssignedIdentityId is a struct representing the Resource ID for a User Assigned Identity
 type UserAssignedIdentityId struct {
-	SubscriptionId    string
-	ResourceGroupName string
-	ResourceName      string
+	SubscriptionId           string
+	ResourceGroupName        string
+	UserAssignedIdentityName string
 }
 
 // NewUserAssignedIdentityID returns a new UserAssignedIdentityId struct
-func NewUserAssignedIdentityID(subscriptionId string, resourceGroupName string, resourceName string) UserAssignedIdentityId {
+func NewUserAssignedIdentityID(subscriptionId string, resourceGroupName string, userAssignedIdentityName string) UserAssignedIdentityId {
 	return UserAssignedIdentityId{
-		SubscriptionId:    subscriptionId,
-		ResourceGroupName: resourceGroupName,
-		ResourceName:      resourceName,
+		SubscriptionId:           subscriptionId,
+		ResourceGroupName:        resourceGroupName,
+		UserAssignedIdentityName: userAssignedIdentityName,
 	}
 }
 
@@ -47,8 +47,8 @@ func ParseUserAssignedIdentityID(input string) (*UserAssignedIdentityId, error) 
 		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
 	}
 
-	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+	if id.UserAssignedIdentityName, ok = parsed.Parsed["userAssignedIdentityName"]; !ok {
+		return nil, fmt.Errorf("the segment 'userAssignedIdentityName' was not found in the resource id %q", input)
 	}
 
 	return &id, nil
@@ -74,8 +74,8 @@ func ParseUserAssignedIdentityIDInsensitively(input string) (*UserAssignedIdenti
 		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
 	}
 
-	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+	if id.UserAssignedIdentityName, ok = parsed.Parsed["userAssignedIdentityName"]; !ok {
+		return nil, fmt.Errorf("the segment 'userAssignedIdentityName' was not found in the resource id %q", input)
 	}
 
 	return &id, nil
@@ -99,7 +99,7 @@ func ValidateUserAssignedIdentityID(input interface{}, key string) (warnings []s
 // ID returns the formatted User Assigned Identity ID
 func (id UserAssignedIdentityId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ManagedIdentity/userAssignedIdentities/%s"
-	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.ResourceName)
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.UserAssignedIdentityName)
 }
 
 // Segments returns a slice of Resource ID Segments which comprise this User Assigned Identity ID
@@ -112,7 +112,7 @@ func (id UserAssignedIdentityId) Segments() []resourceids.Segment {
 		resourceids.StaticSegment("providers", "providers", "providers"),
 		resourceids.ResourceProviderSegment("resourceProvider", "Microsoft.ManagedIdentity", "Microsoft.ManagedIdentity"),
 		resourceids.StaticSegment("userAssignedIdentities", "userAssignedIdentities", "userAssignedIdentities"),
-		resourceids.UserSpecifiedSegment("resourceName", "resourceValue"),
+		resourceids.UserSpecifiedSegment("userAssignedIdentityName", "userAssignedIdentityValue"),
 	}
 }
 
@@ -121,7 +121,7 @@ func (id UserAssignedIdentityId) String() string {
 	components := []string{
 		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
 		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
-		fmt.Sprintf("Resource Name: %q", id.ResourceName),
+		fmt.Sprintf("Name: %q", id.UserAssignedIdentityName),
 	}
 	return fmt.Sprintf("User Assigned Identity (%s)", strings.Join(components, "\n"))
 }

--- a/resourcemanager/commonids/user_assigned_identity_test.go
+++ b/resourcemanager/commonids/user_assigned_identity_test.go
@@ -12,7 +12,7 @@ import (
 var _ resourceids.ResourceId = UserAssignedIdentityId{}
 
 func TestNewUserAssignedIdentityID(t *testing.T) {
-	id := NewUserAssignedIdentityID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue")
+	id := NewUserAssignedIdentityID("12345678-1234-9876-4563-123456789012", "example-resource-group", "userAssignedIdentityName")
 
 	if id.SubscriptionId != "12345678-1234-9876-4563-123456789012" {
 		t.Fatalf("Expected %q but got %q for Segment 'SubscriptionId'", id.SubscriptionId, "12345678-1234-9876-4563-123456789012")
@@ -22,14 +22,14 @@ func TestNewUserAssignedIdentityID(t *testing.T) {
 		t.Fatalf("Expected %q but got %q for Segment 'ResourceGroupName'", id.ResourceGroupName, "example-resource-group")
 	}
 
-	if id.ResourceName != "resourceValue" {
-		t.Fatalf("Expected %q but got %q for Segment 'ResourceName'", id.ResourceName, "resourceValue")
+	if id.UserAssignedIdentityName != "userAssignedIdentityName" {
+		t.Fatalf("Expected %q but got %q for Segment 'UserAssignedIdentityName'", id.UserAssignedIdentityName, "userAssignedIdentityName")
 	}
 }
 
 func TestFormatUserAssignedIdentityID(t *testing.T) {
-	actual := NewUserAssignedIdentityID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue").ID()
-	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/resourceValue"
+	actual := NewUserAssignedIdentityID("12345678-1234-9876-4563-123456789012", "example-resource-group", "userAssignedIdentityName").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/userAssignedIdentityName"
 	if actual != expected {
 		t.Fatalf("Expected the Formatted ID to be %q but got %q", expected, actual)
 	}
@@ -83,16 +83,16 @@ func TestParseUserAssignedIdentityID(t *testing.T) {
 		},
 		{
 			// Valid URI
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/resourceValue",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/userAssignedIdentityName",
 			Expected: &UserAssignedIdentityId{
-				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
-				ResourceGroupName: "example-resource-group",
-				ResourceName:      "resourceValue",
+				SubscriptionId:           "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName:        "example-resource-group",
+				UserAssignedIdentityName: "userAssignedIdentityName",
 			},
 		},
 		{
 			// Invalid (Valid Uri with Extra segment)
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/resourceValue/extra",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/userAssignedIdentityName/extra",
 			Error: true,
 		},
 	}
@@ -119,8 +119,8 @@ func TestParseUserAssignedIdentityID(t *testing.T) {
 			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
 		}
 
-		if actual.ResourceName != v.Expected.ResourceName {
-			t.Fatalf("Expected %q but got %q for ResourceName", v.Expected.ResourceName, actual.ResourceName)
+		if actual.UserAssignedIdentityName != v.Expected.UserAssignedIdentityName {
+			t.Fatalf("Expected %q but got %q for UserAssignedIdentityName", v.Expected.UserAssignedIdentityName, actual.UserAssignedIdentityName)
 		}
 
 	}
@@ -209,30 +209,30 @@ func TestParseUserAssignedIdentityIDInsensitively(t *testing.T) {
 		},
 		{
 			// Valid URI
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/resourceValue",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/userAssignedIdentityName",
 			Expected: &UserAssignedIdentityId{
-				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
-				ResourceGroupName: "example-resource-group",
-				ResourceName:      "resourceValue",
+				SubscriptionId:           "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName:        "example-resource-group",
+				UserAssignedIdentityName: "userAssignedIdentityName",
 			},
 		},
 		{
 			// Invalid (Valid Uri with Extra segment)
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/resourceValue/extra",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/userAssignedIdentityName/extra",
 			Error: true,
 		},
 		{
 			// Valid URI (mIxEd CaSe since this is insensitive)
-			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.mAnAgEdIdEnTiTy/uSeRaSsIgNeDiDeNtItIeS/rEsOuRcEvAlUe",
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.mAnAgEdIdEnTiTy/uSeRaSsIgNeDiDeNtItIeS/uSeRAsSiGnEdIdEnTiTyNaMe",
 			Expected: &UserAssignedIdentityId{
-				SubscriptionId:    "12345678-1234-9876-4563-123456789012",
-				ResourceGroupName: "eXaMpLe-rEsOuRcE-GrOuP",
-				ResourceName:      "rEsOuRcEvAlUe",
+				SubscriptionId:           "12345678-1234-9876-4563-123456789012",
+				ResourceGroupName:        "eXaMpLe-rEsOuRcE-GrOuP",
+				UserAssignedIdentityName: "uSeRAsSiGnEdIdEnTiTyNaMe",
 			},
 		},
 		{
 			// Invalid (Valid Uri with Extra segment - mIxEd CaSe since this is insensitive)
-			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.mAnAgEdIdEnTiTy/uSeRaSsIgNeDiDeNtItIeS/rEsOuRcEvAlUe/extra",
+			Input: "/sUbScRiPtIoNs/12345678-1234-9876-4563-123456789012/rEsOuRcEgRoUpS/eXaMpLe-rEsOuRcE-GrOuP/pRoViDeRs/mIcRoSoFt.mAnAgEdIdEnTiTy/uSeRaSsIgNeDiDeNtItIeS/uSeRAsSiGnEdIdEnTiTyNaMe/extra",
 			Error: true,
 		},
 	}
@@ -259,8 +259,8 @@ func TestParseUserAssignedIdentityIDInsensitively(t *testing.T) {
 			t.Fatalf("Expected %q but got %q for ResourceGroupName", v.Expected.ResourceGroupName, actual.ResourceGroupName)
 		}
 
-		if actual.ResourceName != v.Expected.ResourceName {
-			t.Fatalf("Expected %q but got %q for ResourceName", v.Expected.ResourceName, actual.ResourceName)
+		if actual.UserAssignedIdentityName != v.Expected.UserAssignedIdentityName {
+			t.Fatalf("Expected %q but got %q for UserAssignedIdentityName", v.Expected.UserAssignedIdentityName, actual.UserAssignedIdentityName)
 		}
 
 	}


### PR DESCRIPTION
Matching the behaviour introduced in https://github.com/hashicorp/pandora/pull/2011 which unblocks fixing https://github.com/hashicorp/pandora/actions/runs/4073772510