### PR TITLE
`AzureEnvironmentByNameFromEndpoint`|`IsEnvironmentAzureStack` not restrict the `metadataHost` only to be a hostname

### DIFF
--- a/authentication/environment_test.go
+++ b/authentication/environment_test.go
@@ -48,11 +48,18 @@ func TestAccAzureEnvironmentByName(t *testing.T) {
 	if !strings.EqualFold(env.Name, "AzureChinaCloud") {
 		t.Fatalf("Incorrect environment name returned. Expected: %q. Received: %q", "AzureChinaCloud", env.Name)
 	}
-
 }
 
 func TestAccAzureEnvironmentByNameFromEndpoint(t *testing.T) {
 	env, err := AzureEnvironmentByNameFromEndpoint(context.TODO(), "management.azure.com", "AzureCloud")
+	if err != nil {
+		t.Fatalf("Error getting Endpoint: %s", err)
+	}
+	if !strings.EqualFold(env.Name, "AzureCloud") {
+		t.Fatalf("Incorrect environment name returned. Expected: %q. Received: %q", "AzureCloud", env.Name)
+	}
+	// Same as above, except the metadata host has the scheme specified
+	env, err = AzureEnvironmentByNameFromEndpoint(context.TODO(), "https://management.azure.com", "AzureCloud")
 	if err != nil {
 		t.Fatalf("Error getting Endpoint: %s", err)
 	}
@@ -81,10 +88,20 @@ func TestAccAzureEnvironmentByNameFromEndpoint(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected error from bad environment")
 	}
+
 }
 
 func TestAccIsEnvironmentAzureStack(t *testing.T) {
 	ok, err := IsEnvironmentAzureStack(context.TODO(), "management.azure.com", "public")
+	if err != nil {
+		t.Fatalf("Error getting Endpoint: %s", err)
+	}
+	if ok {
+		t.Fatal("Expected `public` environment to not be Azure Stack")
+	}
+
+	// Same as above, except the metadata host has the scheme specified
+	ok, err = IsEnvironmentAzureStack(context.TODO(), "https://management.azure.com", "public")
 	if err != nil {
 		t.Fatalf("Error getting Endpoint: %s", err)
 	}


### PR DESCRIPTION
Previously, the `endpoint` in the function `AzureEnvironmentByNameFromEndpoint` and `IsEnvironmentAzureStack` represents only the host name, and fix the request to the metadata host to using https. This makes customized metadata host (mostly running in localhost) has to run in HTTPS, which is not convenient sometimes. This PR relax that restriction to supports either a host name or a host name with scheme specified, in a non-breaking way.