### PR TITLE
support resource providers cache

### DIFF
--- a/resourceproviders/cache.go
+++ b/resourceproviders/cache.go
@@ -1,0 +1,31 @@
+package resourceproviders
+
+import (
+	"context"
+
+	"github.com/Azure/azure-sdk-for-go/profiles/2017-03-09/resources/mgmt/resources"
+)
+
+// cachedResourceProviders can be (validly) nil - as such this shouldn't be relied on
+var cachedResourceProviders *[]resources.Provider
+
+// CacheSupportedProviders attempts to retrieve the supported Resource Providers from the Resource Manager API
+// and caches them, for used in enhanced validation
+func CacheSupportedProviders(ctx context.Context, client *resources.ProvidersClient) error {
+	if cachedResourceProviders != nil {
+		return nil
+	}
+	providers, err := availableResourceProviders(ctx, client)
+	if err != nil {
+		return err
+	}
+	cached := make([]resources.Provider, 0)
+	for _, provider := range providers {
+		cached = append(cached, resources.Provider{
+			Namespace:         provider.Namespace,
+			RegistrationState: provider.RegistrationState,
+		})
+	}
+	cachedResourceProviders = &cached
+	return nil
+}

--- a/resourceproviders/cache_azure.go
+++ b/resourceproviders/cache_azure.go
@@ -1,0 +1,16 @@
+package resourceproviders
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/profiles/2017-03-09/resources/mgmt/resources"
+)
+
+func availableResourceProviders(ctx context.Context, client *resources.ProvidersClient) ([]resources.Provider, error) {
+	providers, err := client.List(ctx, nil, "")
+	if err != nil {
+		return nil, fmt.Errorf("listing Resource Providers: %+v", err)
+	}
+	return providers.Values(), nil
+}

--- a/resourceproviders/validation.go
+++ b/resourceproviders/validation.go
@@ -1,0 +1,59 @@
+package resourceproviders
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+// EnhancedValidate returns a validation function which attempts to validate the Resource Provider
+// against the list of Resource Provider supported by this Azure Environment.
+//
+// NOTE: this is best-effort - if the users offline, or the API doesn't return it we'll
+// fall back to the original approach
+func EnhancedValidate(i interface{}, k string) ([]string, []error) {
+	if cachedResourceProviders == nil {
+		return validation.StringIsNotEmpty(i, k)
+	}
+
+	return enhancedValidation(i, k)
+}
+
+func enhancedValidation(i interface{}, k string) ([]string, []error) {
+	v, ok := i.(string)
+	if !ok {
+		return nil, []error{fmt.Errorf("expected type of %q to be string", k)}
+	}
+
+	if v == "" {
+		return nil, []error{fmt.Errorf("%q must not be empty", k)}
+	}
+
+	// enhanced validation is unavailable, but we're in this method..
+	if cachedResourceProviders == nil {
+		return nil, nil
+	}
+
+	found := false
+	for _, provider := range *cachedResourceProviders {
+		if provider.Namespace != nil && *provider.Namespace == v {
+			found = true
+		}
+	}
+
+	if !found {
+		cachedResourceProvidersNames := make([]string, 0)
+		for _, provider := range *cachedResourceProviders {
+			if provider.Namespace != nil {
+				cachedResourceProvidersNames = append(cachedResourceProvidersNames, *provider.Namespace)
+			}
+		}
+		providersJoined := strings.Join(cachedResourceProvidersNames, ", ")
+		return nil, []error{
+			fmt.Errorf("%q was not found in the list of supported Resource Providers: %q", v, providersJoined),
+		}
+	}
+
+	return nil, nil
+}

--- a/resourceproviders/validation_test.go
+++ b/resourceproviders/validation_test.go
@@ -1,0 +1,46 @@
+package resourceproviders
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/profiles/2017-03-09/resources/mgmt/resources"
+)
+
+func TestEnhancedValidationEnabled(t *testing.T) {
+	testCases := []struct {
+		input string
+		valid bool
+	}{
+		{
+			input: "",
+			valid: false,
+		},
+		{
+			input: "micr0soft",
+			valid: false,
+		},
+		{
+			input: "microsoft.compute",
+			valid: false,
+		},
+		{
+			input: "Microsoft.Compute",
+			valid: true,
+		},
+	}
+	namespace := "Microsoft.Compute"
+	cachedResourceProviders = &[]resources.Provider{{Namespace: &namespace}}
+	defer func() {
+		cachedResourceProviders = nil
+	}()
+
+	for _, testCase := range testCases {
+		t.Logf("Testing %q..", testCase.input)
+
+		warnings, errors := EnhancedValidate(testCase.input, "name")
+		valid := len(warnings) == 0 && len(errors) == 0
+		if testCase.valid != valid {
+			t.Errorf("Expected %t but got %t", testCase.valid, valid)
+		}
+	}
+}


### PR DESCRIPTION
This PR moved the resource providers cache logic from `terraform-provider-azurerm`, so we can have the same approaches for both location and rp cache.

It also refactored the logic to ensure resource providers are registered, after moving from `terraform-provider-azurerm`, it can reuse the cached resource providers.
