### PR TITLE
Add pointer FromSliceOrOmitEmpty

### DIFF
--- a/lang/pointer/generic.go
+++ b/lang/pointer/generic.go
@@ -17,3 +17,11 @@ func From[T any](input *T) (output T) {
 func To[T any](input T) *T {
 	return &input
 }
+
+// From a generic list that returns a pointer of the list or nil if the emptylist is empty.
+func FromSliceOrOmitEmpty[T any](input []T) *[]T {
+	if len(input) == 0 {
+		return nil
+	}
+	return &input
+}

--- a/lang/pointer/pointer_test.go
+++ b/lang/pointer/pointer_test.go
@@ -86,4 +86,15 @@ func TestFrom_MapOfInterface(t *testing.T) {
 	}
 }
 
+func TestFromSliceOrOmitEmpty(t *testing.T) {
+	var empty [0]int64
+	var full := []int64{"0", "1", "2"}
+	if actual := pointer.FromSliceOrOmitEmpty(empty); actual != nil {
+		t.Fatal("empty")
+	}
+	if actual := pointer.FromSliceOrOmitEmpty(full); !reflect.DeepEqual(actual, full) {
+		t.Fatal("full")
+	}
+}
+
 // TODO - More comprehensive type coverage?


### PR DESCRIPTION
A new method to return a `nil` if the slice is empty could be used in a solution for [Authentication not working with auth_settings_v2 because of not-omitted empty validation checks (#20820)](https://github.com/hashicorp/terraform-provider-azurerm/issues/20820) .