### PR TITLE
AzureEnvironmentFromEndpoint

### DIFF
--- a/authentication/environment_test.go
+++ b/authentication/environment_test.go
@@ -102,6 +102,22 @@ func TestAccAzureEnvironmentFromEndpoint(t *testing.T) {
 		t.Fatalf("Incorrect environment name returned. Expected: %q. Received: %q", "AzureCloud", env.Name)
 	}
 
+	env, err = AzureEnvironmentFromEndpoint(context.TODO(), "management.chinacloudapi.cn")
+	if err != nil {
+		t.Fatalf("Error getting Endpoint: %s", err)
+	}
+	if !strings.EqualFold(env.Name, "AzureChinaCloud") {
+		t.Fatalf("Incorrect environment name returned. Expected: %q. Received: %q", "AzureChinaCloud", env.Name)
+	}
+
+	env, err = AzureEnvironmentFromEndpoint(context.TODO(), "management.usgovcloudapi.net")
+	if err != nil {
+		t.Fatalf("Error getting Endpoint: %s", err)
+	}
+	if !strings.EqualFold(env.Name, "AzureUSGovernment") {
+		t.Fatalf("Incorrect environment name returned. Expected: %q. Received: %q", "AzureUSGovernment", env.Name)
+	}
+
 	_, err = AzureEnvironmentFromEndpoint(context.TODO(), "badurl")
 	if err == nil {
 		t.Fatal("Expected error from bad endpoint")

--- a/authentication/environment_test.go
+++ b/authentication/environment_test.go
@@ -92,3 +92,18 @@ func TestAccIsEnvironmentAzureStack(t *testing.T) {
 		t.Fatal("Expected `public` environment to not be Azure Stack")
 	}
 }
+
+func TestAccAzureEnvironmentFromEndpoint(t *testing.T) {
+	env, err := AzureEnvironmentFromEndpoint(context.TODO(), "management.azure.com")
+	if err != nil {
+		t.Fatalf("Error getting Endpoint: %s", err)
+	}
+	if !strings.EqualFold(env.Name, "AzureCloud") {
+		t.Fatalf("Incorrect environment name returned. Expected: %q. Received: %q", "AzureCloud", env.Name)
+	}
+
+	_, err = AzureEnvironmentFromEndpoint(context.TODO(), "badurl")
+	if err == nil {
+		t.Fatal("Expected error from bad endpoint")
+	}
+}


### PR DESCRIPTION
- the latest API version of ARM metadata endpoint returns only one environment that the endpoint host belongs to.
- Added a new function to use the new API version so that it takes off the dependency on the cloud name parameter.