### PR TITLE
`identity`/`commonschema`: add support for `SystemOrSingleUserAssignedIdentity`

### DIFF
--- a/resourcemanager/commonschema/identity_system_or_single_user.go
+++ b/resourcemanager/commonschema/identity_system_or_single_user.go
@@ -1,0 +1,208 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package commonschema
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+// NOTE: we intentionally don't have an Optional & Computed here for behavioural consistency.
+
+// NOTE: there's two different types of SystemOrSingleUserAssignedIdentity supported by Azure:
+// The first (List) represents the IdentityIDs as a List of Strings
+// The other (Map) represents the IdentityIDs as a Map of String : Object (containing Client/PrincipalID)
+// from a users perspective however, these should both be represented using the same schema
+// so we have a single schema and separate Expand/Flatten functions
+
+// SystemOrSingleUserAssignedIdentityRequired returns the System or User Assigned Identity schema where this is Required
+func SystemOrSingleUserAssignedIdentityRequired() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Required: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"type": {
+					Type:     schema.TypeString,
+					Required: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						string(identity.TypeUserAssigned),
+						string(identity.TypeSystemAssigned),
+					}, false),
+				},
+				"identity_ids": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Schema{
+						Type:         schema.TypeString,
+						ValidateFunc: commonids.ValidateUserAssignedIdentityID,
+					},
+				},
+				"principal_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"tenant_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			},
+		},
+	}
+}
+
+// SystemOrSingleUserAssignedIdentityRequiredForceNew returns the System or User Assigned Identity schema where this is Required and ForceNew
+func SystemOrSingleUserAssignedIdentityRequiredForceNew() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Required: true,
+		ForceNew: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"type": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						string(identity.TypeUserAssigned),
+						string(identity.TypeSystemAssigned),
+					}, false),
+				},
+				"identity_ids": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					ForceNew: true,
+					MaxItems: 1,
+					Elem: &schema.Schema{
+						Type:         schema.TypeString,
+						ValidateFunc: commonids.ValidateUserAssignedIdentityID,
+					},
+				},
+				"principal_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"tenant_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			},
+		},
+	}
+}
+
+// SystemOrSingleUserAssignedIdentityOptional returns the System or User Assigned Identity schema where this is Optional
+func SystemOrSingleUserAssignedIdentityOptional() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"type": {
+					Type:     schema.TypeString,
+					Required: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						string(identity.TypeUserAssigned),
+						string(identity.TypeSystemAssigned),
+					}, false),
+				},
+				"identity_ids": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Schema{
+						Type:         schema.TypeString,
+						ValidateFunc: commonids.ValidateUserAssignedIdentityID,
+					},
+				},
+				"principal_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"tenant_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			},
+		},
+	}
+}
+
+// SystemOrSingleUserAssignedIdentityOptionalForceNew returns the System or User Assigned Identity schema where this is Optional and ForceNew
+func SystemOrSingleUserAssignedIdentityOptionalForceNew() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		ForceNew: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"type": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						string(identity.TypeUserAssigned),
+						string(identity.TypeSystemAssigned),
+					}, false),
+				},
+				"identity_ids": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					ForceNew: true,
+					MaxItems: 1,
+					Elem: &schema.Schema{
+						Type:         schema.TypeString,
+						ValidateFunc: commonids.ValidateUserAssignedIdentityID,
+					},
+				},
+				"principal_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"tenant_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			},
+		},
+	}
+}
+
+// SystemOrSingleUserAssignedIdentityComputed returns the System or User Assigned Identity schema where this is Computed
+func SystemOrSingleUserAssignedIdentityComputed() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Computed: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"type": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"identity_ids": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+				},
+				"principal_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"tenant_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			},
+		},
+	}
+}

--- a/resourcemanager/identity/system_or_single_user_assigned_list.go
+++ b/resourcemanager/identity/system_or_single_user_assigned_list.go
@@ -1,0 +1,171 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package identity
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+var _ json.Marshaler = &SystemOrSingleUserAssignedList{}
+
+type SystemOrSingleUserAssignedList struct {
+	Type        Type     `json:"type" tfschema:"type"`
+	PrincipalId string   `json:"principalId" tfschema:"principal_id"`
+	TenantId    string   `json:"tenantId" tfschema:"tenant_id"`
+	IdentityIds []string `json:"userAssignedIdentities" tfschema:"identity_ids"`
+}
+
+func (s *SystemOrSingleUserAssignedList) MarshalJSON() ([]byte, error) {
+	// we use a custom marshal function here since we can only send the Type / UserAssignedIdentities field
+	identityType := TypeNone
+	userAssignedIdentityIds := []string{}
+
+	if s != nil {
+		if s.Type == TypeSystemAssigned {
+			identityType = TypeSystemAssigned
+		}
+		if s.Type == TypeUserAssigned {
+			identityType = TypeUserAssigned
+		}
+
+		if identityType != TypeNone {
+			userAssignedIdentityIds = s.IdentityIds
+		}
+	}
+
+	out := map[string]interface{}{
+		"type":                   string(identityType),
+		"userAssignedIdentities": nil,
+	}
+	if len(userAssignedIdentityIds) > 0 {
+		out["userAssignedIdentities"] = userAssignedIdentityIds
+	}
+	return json.Marshal(out)
+}
+
+// ExpandSystemOrSingleUserAssignedList expands the schema input into a SystemOrSingleUserAssignedList struct
+func ExpandSystemOrSingleUserAssignedList(input []interface{}) (*SystemOrSingleUserAssignedList, error) {
+	identityType := TypeNone
+	identityIds := make([]string, 0)
+
+	if len(input) > 0 {
+		raw := input[0].(map[string]interface{})
+		typeRaw := raw["type"].(string)
+		if typeRaw == string(TypeSystemAssigned) {
+			identityType = TypeSystemAssigned
+		}
+		if typeRaw == string(TypeUserAssigned) {
+			identityType = TypeUserAssigned
+		}
+
+		identityIdsRaw := raw["identity_ids"].(*schema.Set).List()
+		for _, v := range identityIdsRaw {
+			identityIds = append(identityIds, v.(string))
+		}
+	}
+
+	if len(identityIds) > 0 && identityType != TypeUserAssigned {
+		return nil, fmt.Errorf("`identity_ids` can only be specified when `type` is set to %q", string(TypeUserAssigned))
+	}
+
+	return &SystemOrSingleUserAssignedList{
+		Type:        identityType,
+		IdentityIds: identityIds,
+	}, nil
+}
+
+// FlattenSystemAssignedOrUserAssignedList turns a SystemOrSingleUserAssignedList into a []interface{}
+func FlattenSystemAssignedOrSingleUserAssignedList(input *SystemOrSingleUserAssignedList) (*[]interface{}, error) {
+	if input == nil {
+		return &[]interface{}{}, nil
+	}
+
+	input.Type = normalizeType(input.Type)
+	if input.Type != TypeSystemAssigned && input.Type != TypeUserAssigned {
+		return &[]interface{}{}, nil
+	}
+
+	identityIds := make([]string, 0)
+	for _, raw := range input.IdentityIds {
+		id, err := commonids.ParseUserAssignedIdentityIDInsensitively(raw)
+		if err != nil {
+			return nil, fmt.Errorf("parsing %q as a User Assigned Identity ID: %+v", raw, err)
+		}
+		identityIds = append(identityIds, id.ID())
+	}
+
+	return &[]interface{}{
+		map[string]interface{}{
+			"type":         string(input.Type),
+			"identity_ids": identityIds,
+			"principal_id": input.PrincipalId,
+			"tenant_id":    input.TenantId,
+		},
+	}, nil
+}
+
+// ExpandSystemOrSingleUserAssignedListFromModel expands the typed schema input into a SystemOrSingleUserAssignedList struct
+func ExpandSystemOrSingleUserAssignedListFromModel(input []ModelSystemAssignedUserAssigned) (*SystemOrSingleUserAssignedList, error) {
+	if len(input) == 0 {
+		return &SystemOrSingleUserAssignedList{
+			Type:        TypeNone,
+			IdentityIds: nil,
+		}, nil
+	}
+
+	identity := input[0]
+
+	if identity.Type == TypeUserAssigned {
+		if len(identity.IdentityIds) == 0 {
+			return nil, fmt.Errorf("`identity_ids` must be specified when `type` is set to %q", TypeUserAssigned)
+		}
+
+		if len(identity.IdentityIds) > 1 {
+			return nil, fmt.Errorf("`identity_ids` can only contain a single identity ID when `type` is set to %q", TypeUserAssigned)
+		}
+	}
+
+	if len(identity.IdentityIds) > 0 && identity.Type != TypeUserAssigned {
+		return nil, fmt.Errorf("`identity_ids` can only be specified when `type` is set to %q", TypeUserAssigned)
+	}
+
+	return &SystemOrSingleUserAssignedList{
+		Type:        identity.Type,
+		IdentityIds: identity.IdentityIds,
+	}, nil
+}
+
+// FlattenSystemAssignedOrSingleUserAssignedListToModel turns a SystemOrSingleUserAssignedList into a typed schema model
+func FlattenSystemAssignedOrSingleUserAssignedListToModel(input *SystemOrSingleUserAssignedList) (*[]ModelSystemAssignedUserAssigned, error) {
+	if input == nil {
+		return &[]ModelSystemAssignedUserAssigned{}, nil
+	}
+
+	input.Type = normalizeType(input.Type)
+	if input.Type != TypeSystemAssigned && input.Type != TypeUserAssigned {
+		return &[]ModelSystemAssignedUserAssigned{}, nil
+	}
+
+	identityIds := make([]string, 0)
+	for _, raw := range input.IdentityIds {
+		id, err := commonids.ParseUserAssignedIdentityIDInsensitively(raw)
+		if err != nil {
+			return nil, fmt.Errorf("parsing %q as a User Assigned Identity ID: %+v", raw, err)
+		}
+		identityIds = append(identityIds, id.ID())
+	}
+
+	return &[]ModelSystemAssignedUserAssigned{
+		{
+			Type:        input.Type,
+			IdentityIds: identityIds,
+			PrincipalId: input.PrincipalId,
+			TenantId:    input.TenantId,
+		},
+	}, nil
+}

--- a/resourcemanager/identity/system_or_single_user_assigned_list_test.go
+++ b/resourcemanager/identity/system_or_single_user_assigned_list_test.go
@@ -1,0 +1,135 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package identity
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestSystemOrSingleUserAssignedListMarshal(t *testing.T) {
+	testData := []struct {
+		input                           *SystemOrSingleUserAssignedList
+		expectedIdentityType            string
+		expectedUserAssignedIdentityIds []string
+	}{
+		{
+			input:                           nil,
+			expectedIdentityType:            "None",
+			expectedUserAssignedIdentityIds: []string{},
+		},
+		{
+			input:                           &SystemOrSingleUserAssignedList{},
+			expectedIdentityType:            "None",
+			expectedUserAssignedIdentityIds: []string{},
+		},
+		{
+			input: &SystemOrSingleUserAssignedList{
+				Type: TypeNone,
+			},
+			expectedIdentityType:            "None",
+			expectedUserAssignedIdentityIds: []string{},
+		},
+		{
+			input: &SystemOrSingleUserAssignedList{
+				Type: TypeNone,
+				IdentityIds: []string{
+					"first",
+				},
+			},
+			expectedIdentityType:            "None",
+			expectedUserAssignedIdentityIds: []string{
+				// intentionally empty since this is bad data
+			},
+		},
+		{
+			input: &SystemOrSingleUserAssignedList{
+				Type:        TypeSystemAssigned,
+				IdentityIds: []string{},
+			},
+			expectedIdentityType:            "SystemAssigned",
+			expectedUserAssignedIdentityIds: []string{},
+		},
+		{
+			input: &SystemOrSingleUserAssignedList{
+				Type:        TypeSystemAssignedUserAssigned,
+				IdentityIds: []string{},
+			},
+			expectedIdentityType:            "None",
+			expectedUserAssignedIdentityIds: []string{},
+		},
+		{
+			input: &SystemOrSingleUserAssignedList{
+				Type:        TypeUserAssigned,
+				IdentityIds: []string{},
+			},
+			expectedIdentityType:            "UserAssigned",
+			expectedUserAssignedIdentityIds: []string{},
+		},
+
+		{
+			input: &SystemOrSingleUserAssignedList{
+				Type: TypeSystemAssignedUserAssigned,
+				IdentityIds: []string{
+					"first",
+					"second",
+				},
+			},
+			expectedIdentityType:            "None",
+			expectedUserAssignedIdentityIds: []string{
+				// bad data
+			},
+		},
+		{
+			input: &SystemOrSingleUserAssignedList{
+				Type: TypeUserAssigned,
+				IdentityIds: []string{
+					"first",
+					"second",
+				},
+			},
+			expectedIdentityType: "UserAssigned",
+			expectedUserAssignedIdentityIds: []string{
+				"first",
+				"second",
+			},
+		},
+	}
+	for i, v := range testData {
+		t.Logf("step %d..", i)
+
+		encoded, err := v.input.MarshalJSON()
+		if err != nil {
+			t.Fatalf("marshaling: %+v", err)
+		}
+
+		var out map[string]interface{}
+		if err := json.Unmarshal(encoded, &out); err != nil {
+			t.Fatalf("decoding: %+v", err)
+		}
+
+		actualIdentityValue := out["type"].(string)
+		if v.expectedIdentityType != actualIdentityValue {
+			t.Fatalf("expected %q but got %q", v.expectedIdentityType, actualIdentityValue)
+		}
+
+		actualUserAssignedIdentityIdsRaw, ok := out["userAssignedIdentities"].([]interface{})
+		if !ok {
+			if len(v.expectedUserAssignedIdentityIds) == 0 {
+				continue
+			}
+
+			t.Fatalf("`userAssignedIdentities` was nil")
+		}
+		actualUserAssignedIdentityIds := make([]string, 0)
+		for _, v := range actualUserAssignedIdentityIdsRaw {
+			actualUserAssignedIdentityIds = append(actualUserAssignedIdentityIds, v.(string))
+		}
+		if !reflect.DeepEqual(v.expectedUserAssignedIdentityIds, actualUserAssignedIdentityIds) {
+			t.Fatalf("expected %q but got %q", strings.Join(v.expectedUserAssignedIdentityIds, ", "), strings.Join(actualUserAssignedIdentityIds, ", "))
+		}
+	}
+}

--- a/resourcemanager/identity/system_or_single_user_assigned_map.go
+++ b/resourcemanager/identity/system_or_single_user_assigned_map.go
@@ -1,0 +1,192 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package identity
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+var _ json.Marshaler = &SystemOrSingleUserAssignedMap{}
+
+type SystemOrSingleUserAssignedMap struct {
+	Type        Type                                   `json:"type" tfschema:"type"`
+	PrincipalId string                                 `json:"principalId" tfschema:"principal_id"`
+	TenantId    string                                 `json:"tenantId" tfschema:"tenant_id"`
+	IdentityIds map[string]UserAssignedIdentityDetails `json:"userAssignedIdentities"`
+}
+
+func (s *SystemOrSingleUserAssignedMap) MarshalJSON() ([]byte, error) {
+	// we use a custom marshal function here since we can only send the Type / UserAssignedIdentities field
+	identityType := TypeNone
+	userAssignedIdentityIds := map[string]UserAssignedIdentityDetails{}
+
+	if s != nil {
+		if s.Type == TypeSystemAssigned {
+			identityType = TypeSystemAssigned
+		}
+		if s.Type == TypeUserAssigned {
+			identityType = TypeUserAssigned
+		}
+
+		if identityType != TypeNone {
+			userAssignedIdentityIds = s.IdentityIds
+		}
+	}
+
+	out := map[string]interface{}{
+		"type":                   string(identityType),
+		"userAssignedIdentities": nil,
+	}
+	if len(userAssignedIdentityIds) > 0 {
+		out["userAssignedIdentities"] = userAssignedIdentityIds
+	}
+	return json.Marshal(out)
+}
+
+// ExpandSystemOrSingleUserAssignedMap expands the schema input into a SystemOrSingleUserAssignedMap struct
+func ExpandSystemOrSingleUserAssignedMap(input []interface{}) (*SystemOrSingleUserAssignedMap, error) {
+	identityType := TypeNone
+	identityIds := make(map[string]UserAssignedIdentityDetails, 0)
+
+	if len(input) > 0 {
+		raw := input[0].(map[string]interface{})
+		typeRaw := raw["type"].(string)
+		if typeRaw == string(TypeSystemAssigned) {
+			identityType = TypeSystemAssigned
+		}
+		if typeRaw == string(TypeUserAssigned) {
+			identityType = TypeUserAssigned
+		}
+
+		identityIdsRaw := raw["identity_ids"].(*schema.Set).List()
+		for _, v := range identityIdsRaw {
+			identityIds[v.(string)] = UserAssignedIdentityDetails{
+				// intentionally empty since the expand shouldn't send these values
+			}
+		}
+	}
+
+	if identityType == TypeUserAssigned {
+		if len(identityIds) == 0 {
+			return nil, fmt.Errorf("`identity_ids` must be specified when `type` is set to %q", TypeUserAssigned)
+		}
+
+		if len(identityIds) > 1 {
+			return nil, fmt.Errorf("`identity_ids` can only contain a single identity ID when `type` is set to %q", TypeUserAssigned)
+		}
+	}
+
+	if len(identityIds) > 0 && identityType != TypeUserAssigned {
+		return nil, fmt.Errorf("`identity_ids` can only be specified when `type` is set to %q", string(TypeUserAssigned))
+	}
+
+	identity := &SystemOrSingleUserAssignedMap{
+		Type:        identityType,
+		IdentityIds: identityIds,
+	}
+
+	return identity, nil
+}
+
+// FlattenSystemOrSingleUserAssignedMap turns a SystemOrSingleUserAssignedMap into a []interface{}
+func FlattenSystemOrSingleUserAssignedMap(input *SystemOrSingleUserAssignedMap) (*[]interface{}, error) {
+	if input == nil {
+		return &[]interface{}{}, nil
+	}
+
+	input.Type = normalizeType(input.Type)
+	if input.Type != TypeSystemAssigned && input.Type != TypeUserAssigned {
+		return &[]interface{}{}, nil
+	}
+
+	identityIds := make([]string, 0)
+	for raw := range input.IdentityIds {
+		id, err := commonids.ParseUserAssignedIdentityIDInsensitively(raw)
+		if err != nil {
+			return nil, fmt.Errorf("parsing %q as a User Assigned Identity ID: %+v", raw, err)
+		}
+		identityIds = append(identityIds, id.ID())
+	}
+
+	return &[]interface{}{
+		map[string]interface{}{
+			"type":         string(input.Type),
+			"identity_ids": identityIds,
+			"principal_id": input.PrincipalId,
+			"tenant_id":    input.TenantId,
+		},
+	}, nil
+}
+
+// ExpandSystemOrSingleUserAssignedMapFromModel expands the typed schema input into a SystemOrSingleUserAssignedMap struct
+func ExpandSystemOrSingleUserAssignedMapFromModel(input []ModelSystemAssignedUserAssigned) (*SystemOrSingleUserAssignedMap, error) {
+	if len(input) == 0 {
+		return &SystemOrSingleUserAssignedMap{
+			Type:        TypeNone,
+			IdentityIds: nil,
+		}, nil
+	}
+
+	identity := input[0]
+
+	identityIds := make(map[string]UserAssignedIdentityDetails, len(identity.IdentityIds))
+	for _, v := range identity.IdentityIds {
+		identityIds[v] = UserAssignedIdentityDetails{
+			// intentionally empty since the expand shouldn't send these values
+		}
+	}
+
+	if identity.Type == TypeUserAssigned {
+		if len(identityIds) == 0 {
+			return nil, fmt.Errorf("`identity_ids` must be specified when `type` is set to %q", TypeUserAssigned)
+		}
+
+		if len(identityIds) > 1 {
+			return nil, fmt.Errorf("`identity_ids` can only contain a single identity ID when `type` is set to %q", TypeUserAssigned)
+		}
+	}
+
+	if len(identityIds) > 0 && identity.Type != TypeUserAssigned {
+		return nil, fmt.Errorf("`identity_ids` can only be specified when `type` is set to %q", TypeUserAssigned)
+	}
+
+	return &SystemOrSingleUserAssignedMap{
+		Type:        identity.Type,
+		IdentityIds: identityIds,
+	}, nil
+}
+
+// FlattenSystemOrSingleUserAssignedMapToModel turns a SystemOrSingleUserAssignedMap into a typed schema model
+func FlattenSystemOrSingleUserAssignedMapToModel(input *SystemOrSingleUserAssignedMap) (*[]ModelSystemAssignedUserAssigned, error) {
+	if input == nil {
+		return &[]ModelSystemAssignedUserAssigned{}, nil
+	}
+
+	input.Type = normalizeType(input.Type)
+	if input.Type != TypeSystemAssigned && input.Type != TypeUserAssigned {
+		return &[]ModelSystemAssignedUserAssigned{}, nil
+	}
+
+	identityIds := make([]string, 0)
+	for raw := range input.IdentityIds {
+		id, err := commonids.ParseUserAssignedIdentityIDInsensitively(raw)
+		if err != nil {
+			return nil, fmt.Errorf("parsing %q as a User Assigned Identity ID: %+v", raw, err)
+		}
+		identityIds = append(identityIds, id.ID())
+	}
+
+	return &[]ModelSystemAssignedUserAssigned{
+		{
+			Type:        input.Type,
+			IdentityIds: identityIds,
+			PrincipalId: input.PrincipalId,
+			TenantId:    input.TenantId,
+		},
+	}, nil
+}

--- a/resourcemanager/identity/system_or_single_user_assigned_map_test.go
+++ b/resourcemanager/identity/system_or_single_user_assigned_map_test.go
@@ -1,0 +1,139 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package identity
+
+import (
+	"encoding/json"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestSystemOrSingleUserAssignedMapMarshal(t *testing.T) {
+	testData := []struct {
+		input                           *SystemOrSingleUserAssignedMap
+		expectedIdentityType            string
+		expectedUserAssignedIdentityIds []string
+	}{
+		{
+			input:                           nil,
+			expectedIdentityType:            "None",
+			expectedUserAssignedIdentityIds: []string{},
+		},
+		{
+			input:                           &SystemOrSingleUserAssignedMap{},
+			expectedIdentityType:            "None",
+			expectedUserAssignedIdentityIds: []string{},
+		},
+		{
+			input: &SystemOrSingleUserAssignedMap{
+				Type: TypeNone,
+			},
+			expectedIdentityType:            "None",
+			expectedUserAssignedIdentityIds: []string{},
+		},
+		{
+			input: &SystemOrSingleUserAssignedMap{
+				Type: TypeNone,
+				IdentityIds: map[string]UserAssignedIdentityDetails{
+					"first": {},
+				},
+			},
+			expectedIdentityType:            "None",
+			expectedUserAssignedIdentityIds: []string{
+				// intentionally empty since this is bad data
+			},
+		},
+		{
+			input: &SystemOrSingleUserAssignedMap{
+				Type:        TypeSystemAssigned,
+				IdentityIds: map[string]UserAssignedIdentityDetails{},
+			},
+			expectedIdentityType:            "SystemAssigned",
+			expectedUserAssignedIdentityIds: []string{},
+		},
+		{
+			input: &SystemOrSingleUserAssignedMap{
+				Type:        TypeSystemAssignedUserAssigned,
+				IdentityIds: map[string]UserAssignedIdentityDetails{},
+			},
+			expectedIdentityType:            "None",
+			expectedUserAssignedIdentityIds: []string{},
+		},
+		{
+			input: &SystemOrSingleUserAssignedMap{
+				Type:        TypeUserAssigned,
+				IdentityIds: map[string]UserAssignedIdentityDetails{},
+			},
+			expectedIdentityType:            "UserAssigned",
+			expectedUserAssignedIdentityIds: []string{},
+		},
+
+		{
+			input: &SystemOrSingleUserAssignedMap{
+				Type: TypeSystemAssignedUserAssigned,
+				IdentityIds: map[string]UserAssignedIdentityDetails{
+					"first":  {},
+					"second": {},
+				},
+			},
+			expectedIdentityType:            "None",
+			expectedUserAssignedIdentityIds: []string{
+				// bad data
+			},
+		},
+		{
+			input: &SystemOrSingleUserAssignedMap{
+				Type: TypeUserAssigned,
+				IdentityIds: map[string]UserAssignedIdentityDetails{
+					"first":  {},
+					"second": {},
+				},
+			},
+			expectedIdentityType: "UserAssigned",
+			expectedUserAssignedIdentityIds: []string{
+				"first",
+				"second",
+			},
+		},
+	}
+	for i, v := range testData {
+		t.Logf("step %d..", i)
+
+		encoded, err := v.input.MarshalJSON()
+		if err != nil {
+			t.Fatalf("marshaling: %+v", err)
+		}
+
+		var out map[string]interface{}
+		if err := json.Unmarshal(encoded, &out); err != nil {
+			t.Fatalf("decoding: %+v", err)
+		}
+
+		actualIdentityValue := out["type"].(string)
+		if v.expectedIdentityType != actualIdentityValue {
+			t.Fatalf("expected %q but got %q", v.expectedIdentityType, actualIdentityValue)
+		}
+
+		actualUserAssignedIdentityIdsRaw, ok := out["userAssignedIdentities"].(map[string]interface{})
+		if !ok {
+			if len(v.expectedUserAssignedIdentityIds) == 0 {
+				continue
+			}
+
+			t.Fatalf("`userAssignedIdentities` was nil")
+		}
+		actualUserAssignedIdentityIds := make([]string, 0)
+		for k := range actualUserAssignedIdentityIdsRaw {
+			actualUserAssignedIdentityIds = append(actualUserAssignedIdentityIds, k)
+		}
+		sort.Strings(v.expectedUserAssignedIdentityIds)
+		sort.Strings(actualUserAssignedIdentityIds)
+
+		if !reflect.DeepEqual(v.expectedUserAssignedIdentityIds, actualUserAssignedIdentityIds) {
+			t.Fatalf("expected %q but got %q", strings.Join(v.expectedUserAssignedIdentityIds, ", "), strings.Join(actualUserAssignedIdentityIds, ", "))
+		}
+	}
+}


### PR DESCRIPTION
This variant of the existing `SystemOrUserAssignedIdentity` is needed due to the `identity` implementation within the Databricks service.