### PR TITLE
Remove default value nil when userAssignedIdentities isn't set

### DIFF
--- a/resourcemanager/identity/legacy_system_and_user_assigned_map.go
+++ b/resourcemanager/identity/legacy_system_and_user_assigned_map.go
@@ -47,8 +47,7 @@ func (s *LegacySystemAndUserAssignedMap) MarshalJSON() ([]byte, error) {
 	}
 
 	out := map[string]interface{}{
-		"type":                   string(identityType),
-		"userAssignedIdentities": nil,
+		"type": string(identityType),
 	}
 	if len(userAssignedIdentityIds) > 0 {
 		out["userAssignedIdentities"] = userAssignedIdentityIds


### PR DESCRIPTION
Symptom:
I am trying to upgrade CosmosDB Account API version from 2021-10-15 to 2023-04-15.
While upgrading, I found that `azurerm_cosmosdb_account` would set `identity` and the type of [identity](https://github.com/hashicorp/terraform-provider-azurerm/blob/78af39aace0eb5640488328f7fbf85e44493d7cf/internal/services/cosmos/cosmosdb_account_resource.go#L759) is defined as [`*identity.LegacySystemAndUserAssignedMap`](https://github.com/hashicorp/go-azure-sdk/blob/f2ebbd5eda8f9476fab78bd3746dd0be4f978d3f/resource-manager/cosmosdb/2023-04-15/cosmosdb/model_databaseaccountcreateupdateparameters.go#L12) in new sdk package. So I use [`identity.ExpandLegacySystemAndUserAssignedMap`](https://github.com/hashicorp/go-azure-helpers/blob/fdb8702aa8c2f2bc5fd66bc4d6557fc09e3e24b3/resourcemanager/identity/legacy_system_and_user_assigned_map.go#L60) to expand it. While using `identity.ExpandLegacySystemAndUserAssignedMap` to expand it, I found it always set `userAssignedIdentities` to `nil` even if this property isn't set in azurerm provider. After investigated, I found the root cause is that [`MarshalJson func`](https://github.com/hashicorp/go-azure-helpers/blob/fdb8702aa8c2f2bc5fd66bc4d6557fc09e3e24b3/resourcemanager/identity/legacy_system_and_user_assigned_map.go#L51) of `*identity.LegacySystemAndUserAssignedMap` always gives `userAssignedIdentities` a default value `nil`. But given new CosmosDB Account API doesn't allow "userAssignedIdentities = nil" and it would fail with below error, so I submit this PR to remove the default value for `userAssignedIdentities` when it isn't specified.

Note: I also found the type of `identity` is defined as [`*ManagedServiceIdentity`](https://github.com/Azure/azure-sdk-for-go/blob/2187aca40bbf6931ffac666977e5d29128d82585/services/cosmos-db/mgmt/2021-10-15/documentdb/models.go#L2002) in old sdk package and its [`MarshalJSON func`](https://github.com/Azure/azure-sdk-for-go/blob/2187aca40bbf6931ffac666977e5d29128d82585/services/cosmos-db/mgmt/2021-10-15/documentdb/models.go#L5104) doesn't give `userAssignedIdentites` the default value `nil` when `userAssignedIdentites` isn't set. So I assume new sdk package also needs to align with it.

Request payload:
```
PUT https://management.azure.com/subscriptions/{{subscriptionId}}/resourceGroups/acctestRG-cosmos-test10/providers/Microsoft.DocumentDB/databaseAccounts/acctest-ca-test10?api-version=2023-04-15

{
    "identity": {
        "type": "None",
        "userAssignedIdentities": null
    },
    "kind": "GlobalDocumentDB",
    "location": "westeurope",
    "properties": {
        "backupPolicy": null,
        "capabilities": [],
        "consistencyPolicy": {
            "defaultConsistencyLevel": "Session",
            "maxIntervalInSeconds": 5,
            "maxStalenessPrefix": 100
        },
        "databaseAccountOfferType": "Standard",
        "disableKeyBasedMetadataWriteAccess": false,
        "disableLocalAuth": false,
        "enableAnalyticalStorage": false,
        "enableAutomaticFailover": false,
        "enableFreeTier": false,
        "enableMultipleWriteLocations": false,
        "ipRules": [],
        "isVirtualNetworkFilterEnabled": false,
        "locations": [
            {
                "failoverPriority": 0,
                "isZoneRedundant": false,
                "locationName": "westeurope"
            }
        ],
        "networkAclBypass": "None",
        "networkAclBypassResourceIds": [],
        "publicNetworkAccess": "Enabled",
        "virtualNetworkRules": []
    },
    "tags": {}
}
```

Error Message:
```
{
    "message": "Object reference not set to an instance of an object.",
    "code": "Internal Server Error"
}
```