### PR TITLE
sql_database: updating the `Parse` method name

### DIFF
--- a/resourcemanager/commonids/sql_database.go
+++ b/resourcemanager/commonids/sql_database.go
@@ -30,8 +30,8 @@ func NewSqlDatabaseID(subscriptionId string, resourceGroupName string, serverNam
 	}
 }
 
-// ParseDatabaseID parses 'input' into a SqlDatabaseId
-func ParseDatabaseID(input string) (*SqlDatabaseId, error) {
+// ParseSqlDatabaseID parses 'input' into a SqlDatabaseId
+func ParseSqlDatabaseID(input string) (*SqlDatabaseId, error) {
 	parser := resourceids.NewParserFromResourceIdType(SqlDatabaseId{})
 	parsed, err := parser.Parse(input, false)
 	if err != nil {
@@ -99,7 +99,7 @@ func ValidateSqlDatabaseID(input interface{}, key string) (warnings []string, er
 		return
 	}
 
-	if _, err := ParseDatabaseID(v); err != nil {
+	if _, err := ParseSqlDatabaseID(v); err != nil {
 		errors = append(errors, err)
 	}
 

--- a/resourcemanager/commonids/sql_database_test.go
+++ b/resourcemanager/commonids/sql_database_test.go
@@ -114,7 +114,7 @@ func TestParseSqlDatabaseID(t *testing.T) {
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing %q", v.Input)
 
-		actual, err := ParseDatabaseID(v.Input)
+		actual, err := ParseSqlDatabaseID(v.Input)
 		if err != nil {
 			if v.Error {
 				continue
@@ -307,7 +307,6 @@ func TestParseSqlDatabaseIDInsensitively(t *testing.T) {
 		if actual.DatabaseName != v.Expected.DatabaseName {
 			t.Fatalf("Expected %q but got %q for DatabaseName", v.Expected.DatabaseName, actual.DatabaseName)
 		}
-
 	}
 }
 


### PR DESCRIPTION
Spotted this bug whilst implementing #198 / reviewing the PR on `hashicorp/terraform-provider-azurerm`