### PR TITLE
`resourceid`: parser supports data plane host segment

### DIFF
--- a/resourcemanager/resourceids/errors.go
+++ b/resourcemanager/resourceids/errors.go
@@ -98,6 +98,11 @@ func descriptionForSpecifiedSegment(segment Segment) (*string, error) {
 			msg := fmt.Sprintf("should be the user specified value for this %s [for example %q]", name, segment.ExampleValue)
 			return &msg, nil
 		}
+	case DataPlaneHostSegmentType:
+		{
+			msg := fmt.Sprintf("should be the data plane host for this %s [for example %q]", segment.Name, segment.ExampleValue)
+			return &msg, nil
+		}
 	}
 
 	return nil, fmt.Errorf("internal-error: the Segment Type %q was not implemented for Segment %q", string(segment.Type), segment.Name)

--- a/resourcemanager/resourceids/interface.go
+++ b/resourcemanager/resourceids/interface.go
@@ -63,6 +63,9 @@ const (
 
 	// UserSpecifiedSegmentType specifies that this Segment is User-Specifiable
 	UserSpecifiedSegmentType SegmentType = "UserSpecified"
+
+	// DataPlaneHostSegmentType sepcifies that this Segment is a Data Plane Host
+	DataPlaneHostSegmentType SegmentType = "DataPlaneHost"
 )
 
 // ConstantSegment is a helper which returns a Segment for a Constant
@@ -127,6 +130,15 @@ func UserSpecifiedSegment(name, exampleValue string) Segment {
 	return Segment{
 		Name:         name,
 		Type:         UserSpecifiedSegmentType,
+		ExampleValue: exampleValue,
+	}
+}
+
+// DataPlaneHostSegment is a helper which returns a Segment for a Data Plane Host
+func DataPlaneHostSegment(name, exampleValue string) Segment {
+	return Segment{
+		Name:         name,
+		Type:         DataPlaneHostSegmentType,
 		ExampleValue: exampleValue,
 	}
 }

--- a/resourcemanager/resourceids/parse_test.go
+++ b/resourcemanager/resourceids/parse_test.go
@@ -1016,6 +1016,50 @@ func TestParseIdContainingJustAScope(t *testing.T) {
 	}
 }
 
+func TestParseIdDataPlane(t *testing.T) {
+	segments := []resourceids.Segment{
+		resourceids.DataPlaneHostSegment("domainName", "domainValue"),
+		resourceids.StaticSegment("staticExample", "example", "example"),
+		resourceids.UserSpecifiedSegment("fooName", "fooValue"),
+		resourceids.UserSpecifiedSegment("barName", "barValue"),
+	}
+	testData := []struct {
+		name        string
+		input       string
+		expected    *resourceids.ParseResult
+		insensitive bool
+	}{
+		{
+			name:        "empty",
+			input:       "",
+			insensitive: false,
+		},
+		{
+			name:        "with https",
+			input:       "https://example.com/example/foo/bar",
+			insensitive: false,
+			expected: &resourceids.ParseResult{
+				Parsed: map[string]string{
+					"domainName":    "https://example.com",
+					"staticExample": "example",
+					"fooName":       "foo",
+					"barName":       "bar",
+				},
+				RawInput: "https://example.com/example/foo/bar",
+			},
+		},
+	}
+	for _, test := range testData {
+		t.Logf("Test %q..", test.name)
+		rid := fakeIdParser{
+			segments,
+		}
+		parser := resourceids.NewParserFromResourceIdType(rid)
+		actual, err := parser.Parse(test.input, test.insensitive)
+		validateResult(t, actual, test.expected, err)
+	}
+}
+
 var _ resourceids.ResourceId = fakeIdParser{}
 
 type fakeIdParser struct {


### PR DESCRIPTION
This PR is to support parsing data plane resource IDs like keyvault/managed hsm keys, secrets for new resource ID format.

Required by: https://github.com/hashicorp/terraform-provider-azurerm/pull/25324