### PR TITLE
automation: switching to use the generic agents

### DIFF
--- a/.github/workflows/automation-release.yaml
+++ b/.github/workflows/automation-release.yaml
@@ -10,7 +10,7 @@ concurrency:
 jobs:
   release-go-azure-helpers:
     if: ${{ github.event.pull_request.merged == true && contains( github.event.pull_request.labels.*.name, 'release-once-merged') }}
-    runs-on: custom-linux-medium
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     outputs:
@@ -38,7 +38,7 @@ jobs:
   conditionally-update-azurerm:
     needs: [release-go-azure-helpers]
     if: ${{github.event.pull_request.merged == true && contains( github.event.pull_request.labels.*.name, 'update-azurerm-after-release') }}
-    runs-on: custom-linux-xl
+    runs-on: ubuntu-latest
     outputs:
       has_changes_to_push: ${{ steps.update-azurerm-provider.outputs.has_changes_to_push }}
     steps:


### PR DESCRIPTION
This updated the GHAs to run on regular `ubuntu-latest` agents - we're not super concerned about the speed at which this runs because releases are irregular - but this should unblock the auto release process.