### PR TITLE
Added `UnmarshalJSON` function for `LegacySystemAndUserAssignedMap` to transform API value as required

### DIFF
--- a/resourcemanager/identity/legacy_system_and_user_assigned_map.go
+++ b/resourcemanager/identity/legacy_system_and_user_assigned_map.go
@@ -6,6 +6,7 @@ package identity
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -54,6 +55,45 @@ func (s *LegacySystemAndUserAssignedMap) MarshalJSON() ([]byte, error) {
 		out["userAssignedIdentities"] = userAssignedIdentityIds
 	}
 	return json.Marshal(out)
+}
+
+func (s *LegacySystemAndUserAssignedMap) UnmarshalJSON(input []byte) error {
+	if input == nil {
+		return nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return fmt.Errorf("unmarshaling LegacySystemAndUserAssignedMap into map[string]interface: %+v", err)
+	}
+	typeVal := TypeNone
+	if v, ok := temp["type"].(string); ok && v != "" {
+		if strings.EqualFold(v, string(TypeSystemAssigned)) {
+			typeVal = TypeSystemAssigned
+		}
+		if strings.EqualFold(v, string(TypeUserAssigned)) {
+			typeVal = TypeUserAssigned
+		}
+		if strings.EqualFold(v, string(typeLegacySystemAssignedUserAssigned)) {
+			typeVal = TypeSystemAssignedUserAssigned
+		}
+		if strings.EqualFold(v, string(TypeSystemAssignedUserAssigned)) {
+			typeVal = TypeSystemAssignedUserAssigned
+		}
+	}
+
+	type alias LegacySystemAndUserAssignedMap
+	var decoded alias
+	if err := json.Unmarshal(input, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+
+	s.Type = typeVal
+	s.IdentityIds = decoded.IdentityIds
+	s.PrincipalId = decoded.PrincipalId
+	s.TenantId = decoded.TenantId
+
+	return nil
 }
 
 // ExpandLegacySystemAndUserAssignedMap expands the schema input into a LegacySystemAndUserAssignedMap struct


### PR DESCRIPTION
If the `type` of `identity` is set to `SystemAssigned, UserAssigned`(w/space), Terraform will return the following 400 error even though the `type` has not changed when updating the resource. It is caused by the [internal error](https://github.com/hashicorp/go-azure-helpers/blob/5b8e01f22f0c7713bf4660645c102916bf71bb7c/resourcemanager/identity/legacy_system_and_user_assigned_map.go#L30) (internal error: the legacy SystemAssigned,UserAssigned identity type should be being converted to the schema type - this is a bug). In this case, the type value returned from API is `SystemAssigned,UserAssigned`(no space) causing this internal error to occur. 

```
Error:
`performing CreateOrUpdate: unexpected status 400 with error: InvalidResource: The resource definition is invalid.`
```

Use the consistent value `SystemAssigned, UserAssigned` internally -  transform from the API value (`SystemAssigned,UserAssigned`) as required when Unmarshalling the JSON payload to fix https://github.com/hashicorp/terraform-provider-azurerm/issues/24390.

Test result:
PASS: TestLegacySystemAndUserAssignedMapUnmarshal (0.00s)

Related PR: https://github.com/hashicorp/terraform-provider-azurerm/pull/25542