### PR TITLE
`resourcemanager/resourceids`: adding a `Match` function

### DIFF
--- a/resourcemanager/features/user_specified_segments.go
+++ b/resourcemanager/features/user_specified_segments.go
@@ -7,7 +7,7 @@ package features
 // Resource ID Segments should be compared case-insensitively as required.
 //
 // @tombuildsstuff: whilst this IS EXPOSED in the public interface - this is NOT READY FOR USE and should
-// not be exposed in user-focused logic at this time, else this'll become a source of knock-on problems
+// not be exposed to users (i.e. as a feature-toggle) until this work is completed - as this'll become a source of knock-on problems
 // rather than being useful.
 //
 // There are a number of dependencies to enabling this, including completing the standardiation on the

--- a/resourcemanager/features/user_specified_segments.go
+++ b/resourcemanager/features/user_specified_segments.go
@@ -1,0 +1,15 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package features
+
+// TreatUserSpecifiedSegmentsAsCaseInsensitive is a feature-toggle which specifies whether User Specified
+// Resource ID Segments should be compared case-insensitively as required.
+//
+// @tombuildsstuff: whilst this IS EXPOSED in the public interface - this is NOT READY FOR USE and should
+// not be exposed in user-focused logic at this time, else this'll become a source of knock-on problems
+// rather than being useful.
+//
+// There are a number of dependencies to enabling this, including completing the standardiation on the
+// `ResourceId` interface and the `ResourceIDReference` schema types - and surrounding updates.
+var TreatUserSpecifiedSegmentsAsCaseInsensitive = false

--- a/resourcemanager/resourceids/match.go
+++ b/resourcemanager/resourceids/match.go
@@ -1,0 +1,61 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package resourceids
+
+import (
+	"reflect"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/features"
+)
+
+// Match compares two instances of the same ResourceId and determines whether they are a match
+//
+// Whilst it might seem fine to compare the result of the `.ID()` function, that doesn't account
+// for Resource ID Segments which need to be compared as case-insensitive.
+//
+// As such whilst this function is NOT exposing that functionality right now, it will when the
+// centralised feature-flag for this is rolled out.
+func Match(first, second ResourceId) bool {
+	// since we're comparing interface types, ensure the two underlying types are the same
+	if reflect.TypeOf(first) != reflect.TypeOf(second) {
+		return false
+	}
+
+	parser := NewParserFromResourceIdType(first)
+	firstParsed, err := parser.Parse(first.ID(), true)
+	if err != nil {
+		return false
+	}
+	secondParsed, err := parser.Parse(second.ID(), true)
+	if err != nil {
+		return false
+	}
+	firstVal := firstParsed.Parsed
+	secondVal := secondParsed.Parsed
+	if len(firstVal) != len(secondVal) {
+		return false
+	}
+	for key, val := range firstVal {
+		otherVal, ok := secondVal[key]
+		if !ok {
+			return false
+		}
+
+		segment := parser.namedSegment(key)
+		if segment == nil {
+			return false
+		}
+
+		if features.TreatUserSpecifiedSegmentsAsCaseInsensitive && segment.Type == UserSpecifiedSegmentType {
+			if !strings.EqualFold(val, otherVal) {
+				return false
+			}
+		} else if val != otherVal {
+			return false
+		}
+	}
+
+	return true
+}

--- a/resourcemanager/resourceids/match_test.go
+++ b/resourcemanager/resourceids/match_test.go
@@ -1,0 +1,211 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package resourceids
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/features"
+)
+
+func TestMatch(t *testing.T) {
+	// force a case-sensitive comparison for this test
+	features.TreatUserSpecifiedSegmentsAsCaseInsensitive = false
+
+	testData := []struct {
+		first    ResourceId
+		second   ResourceId
+		expected bool
+	}{
+		{
+			// two instances of the same Resource ID with the same value should match
+			first:    newPlanetID("mars"),
+			second:   newPlanetID("mars"),
+			expected: true,
+		},
+		{
+			// two instances of the same Resource ID with the same value in differing casing
+			// shouldn't match
+			first:    newPlanetID("mars"),
+			second:   newPlanetID("mArs"),
+			expected: false,
+		},
+		{
+			// two instances of the same Resource ID with differing values shouldn't match
+			first:    newPlanetID("earth"),
+			second:   newPlanetID("mars"),
+			expected: false,
+		},
+		{
+			// two different Resource ID types shouldn't match - same URI
+			first:    newPlanetID("earth"),
+			second:   newOtherPlanetID("earth"),
+			expected: false,
+		},
+		{
+			// two different Resource ID types shouldn't match - different URIs
+			first:    newPlanetID("earth"),
+			second:   newSolarSystemPlanetID("milkyWay", "earth"),
+			expected: false,
+		},
+	}
+	for i, data := range testData {
+		t.Logf("Iteration %d", i)
+		actual := Match(data.first, data.second)
+		if actual != data.expected {
+			t.Fatalf("expected Match to return %t but got %t", data.expected, actual)
+		}
+	}
+}
+
+func TestMatch_Insensitive(t *testing.T) {
+	// force a case-sensitive comparison for this test
+	features.TreatUserSpecifiedSegmentsAsCaseInsensitive = true
+
+	testData := []struct {
+		first    ResourceId
+		second   ResourceId
+		expected bool
+	}{
+		{
+			// two instances of the same Resource ID with the same value should match
+			first:    newPlanetID("mars"),
+			second:   newPlanetID("mars"),
+			expected: true,
+		},
+		{
+			// two instances of the same Resource ID with the same value in differing casing
+			// should match since the feature-flag is enabled
+			first:    newPlanetID("mars"),
+			second:   newPlanetID("mArs"),
+			expected: true,
+		},
+		{
+			// two instances of the same Resource ID with differing values shouldn't match
+			first:    newPlanetID("earth"),
+			second:   newPlanetID("mars"),
+			expected: false,
+		},
+		{
+			// two different Resource ID types shouldn't match - same URI
+			first:    newPlanetID("earth"),
+			second:   newOtherPlanetID("earth"),
+			expected: false,
+		},
+		{
+			// two different Resource ID types shouldn't match - different URIs
+			first:    newPlanetID("earth"),
+			second:   newSolarSystemPlanetID("milkyWay", "earth"),
+			expected: false,
+		},
+	}
+	for i, data := range testData {
+		t.Logf("Iteration %d", i)
+		actual := Match(data.first, data.second)
+		if actual != data.expected {
+			t.Fatalf("expected Match to return %t but got %t", data.expected, actual)
+		}
+	}
+}
+
+// NOTE: the ResourceId implementations below are purely for test purposes and so intentionally
+// incomplete implementations/panicking for unexpected/unused methods
+
+var _ ResourceId = &planetResourceId{}
+
+type planetResourceId struct {
+	planetName string
+}
+
+func newPlanetID(planetName string) *planetResourceId {
+	return &planetResourceId{
+		planetName: planetName,
+	}
+}
+
+func (f *planetResourceId) FromParseResult(_ ParseResult) error {
+	panic("not implemented since this codepath should not be used")
+}
+
+func (f *planetResourceId) ID() string {
+	return fmt.Sprintf("/planets/%s", f.planetName)
+}
+
+func (f *planetResourceId) String() string {
+	panic("not implemented since this codepath should not be used")
+}
+
+func (f *planetResourceId) Segments() []Segment {
+	return []Segment{
+		StaticSegment("planets", "planets", "planets"),
+		UserSpecifiedSegment("planetName", "earth"),
+	}
+}
+
+var _ ResourceId = &otherPlanetResourceId{}
+
+type otherPlanetResourceId struct {
+	planetName string
+}
+
+func newOtherPlanetID(planetName string) *otherPlanetResourceId {
+	return &otherPlanetResourceId{
+		planetName: planetName,
+	}
+}
+
+func (f *otherPlanetResourceId) FromParseResult(_ ParseResult) error {
+	panic("not implemented since this codepath should not be used")
+}
+
+func (f *otherPlanetResourceId) ID() string {
+	return fmt.Sprintf("/planets/%s", f.planetName)
+}
+
+func (f *otherPlanetResourceId) String() string {
+	panic("not implemented since this codepath should not be used")
+}
+
+func (f *otherPlanetResourceId) Segments() []Segment {
+	return []Segment{
+		StaticSegment("planets", "planets", "planets"),
+		UserSpecifiedSegment("planetName", "earth"),
+	}
+}
+
+var _ ResourceId = &solarSystemPlanetResourceId{}
+
+type solarSystemPlanetResourceId struct {
+	planetName      string
+	solarSystemName string
+}
+
+func newSolarSystemPlanetID(solarSystemName, planetName string) *solarSystemPlanetResourceId {
+	return &solarSystemPlanetResourceId{
+		planetName:      planetName,
+		solarSystemName: solarSystemName,
+	}
+}
+
+func (f *solarSystemPlanetResourceId) FromParseResult(_ ParseResult) error {
+	panic("not implemented since this codepath should not be used")
+}
+
+func (f *solarSystemPlanetResourceId) ID() string {
+	return fmt.Sprintf("/solarSystems/%s/planets/%s", f.solarSystemName, f.planetName)
+}
+
+func (f *solarSystemPlanetResourceId) String() string {
+	panic("not implemented since this codepath should not be used")
+}
+
+func (f *solarSystemPlanetResourceId) Segments() []Segment {
+	return []Segment{
+		StaticSegment("solarSystems", "solarSystems", "solarSystems"),
+		UserSpecifiedSegment("solarSystemName", "milkyWay"),
+		StaticSegment("planets", "planets", "planets"),
+		UserSpecifiedSegment("planetName", "earth"),
+	}
+}

--- a/resourcemanager/resourceids/parse.go
+++ b/resourcemanager/resourceids/parse.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 )
 
 type Parser struct {
@@ -203,6 +205,17 @@ func (p Parser) Parse(input string, insensitively bool) (*ParseResult, error) {
 		}
 	}
 	return &parseResult, nil
+}
+
+// namedSegment returns the named Segment for a ResourceId, if it exists
+func (p Parser) namedSegment(name string) *Segment {
+	for _, item := range p.segments {
+		if item.Name == name {
+			return pointer.To(item)
+		}
+	}
+
+	return nil
 }
 
 func (p Parser) parseScopePrefix(input, regexForNonScopeSegments string, insensitively bool) (*string, error) {


### PR DESCRIPTION
The `Match` function takes two instances of the ResourceId type and allows comparing the parsed segments for these.

Whilst this is also possible by comparing the value of `.ID()` in both instances - that's not case-aware and so will be problematic in the future - hence the need for this function which can account for case-aware comparisons.

This also exposed a feature-flag for treating User Specified Segments as case-insensitive for comparison purposes - however this isn't usable at this time and so **must not** be exposed as a toggle at this point-in-time, since it'll cause more problems than it solves. However having this internal-only feature flag allows us to built out the surrounding components ahead-of-time and add tests covering both scenarios - therefore this is beneficial to have as an internal toggle today - even if it's not usable for end-users for some time.

There are currently 6 instances of this across the Provider:

![Screenshot 2024-05-06 at 13 02 05](https://github.com/hashicorp/go-azure-helpers/assets/666005/cb0fb2cf-68be-49be-8620-379e9d08a0c9)

in addition to (at least) https://github.com/hashicorp/terraform-provider-azurerm/pull/25809 - therefore we should get ahead of this and switch to using `resourceids.Match` to enable us to handle this consistently in the future.