### PR TITLE
`commonschema`: adding a new Common Schema type and Constant for Public Network Access

### DIFF
--- a/resourcemanager/commonschema/public_network_access.go
+++ b/resourcemanager/commonschema/public_network_access.go
@@ -1,0 +1,68 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package commonschema
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/network"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+// PublicNetworkAccessOptional returns the schema for a `public_network_access` field that is Optional.
+func PublicNetworkAccessOptional(supportsSecuredByPerimeter bool) *schema.Schema {
+	return &schema.Schema{
+		Type:         schema.TypeString,
+		Optional:     true,
+		Default:      string(network.PublicNetworkAccessEnabled),
+		ValidateFunc: validationFunctionForPublicNetworkAccess(supportsSecuredByPerimeter),
+	}
+}
+
+// PublicNetworkAccessOptionalForceNew returns the schema for a `public_network_access` field that
+// is both Optional and ForceNew.
+func PublicNetworkAccessOptionalForceNew(supportsSecuredByPerimeter bool) *schema.Schema {
+	return &schema.Schema{
+		Type:         schema.TypeString,
+		Optional:     true,
+		Default:      string(network.PublicNetworkAccessEnabled),
+		ForceNew:     true,
+		ValidateFunc: validationFunctionForPublicNetworkAccess(supportsSecuredByPerimeter),
+	}
+}
+
+// PublicNetworkAccessRequired returns the schema for a `public_network_access` field that is Required.
+func PublicNetworkAccessRequired(supportsSecuredByPerimeter bool) *schema.Schema {
+	return &schema.Schema{
+		Type:         schema.TypeString,
+		Required:     true,
+		ValidateFunc: validationFunctionForPublicNetworkAccess(supportsSecuredByPerimeter),
+	}
+}
+
+// PublicNetworkAccessRequiredForceNew returns the schema for a `public_network_access` field that
+// is both Required and ForceNew.
+func PublicNetworkAccessRequiredForceNew(supportsSecuredByPerimeter bool) *schema.Schema {
+	return &schema.Schema{
+		Type:         schema.TypeString,
+		Required:     true,
+		ForceNew:     true,
+		ValidateFunc: validationFunctionForPublicNetworkAccess(supportsSecuredByPerimeter),
+	}
+}
+
+// validationFunctionForPublicNetworkAccess returns the validation function for the `public_network_access` field
+func validationFunctionForPublicNetworkAccess(supportsSecuredByPerimeter bool) schema.SchemaValidateFunc {
+	if supportsSecuredByPerimeter {
+		return validation.StringInSlice([]string{
+			string(network.PublicNetworkAccessDisabled),
+			string(network.PublicNetworkAccessEnabled),
+			string(network.PublicNetworkAccessSecuredByPerimeter),
+		}, false)
+	}
+
+	return validation.StringInSlice([]string{
+		string(network.PublicNetworkAccessDisabled),
+		string(network.PublicNetworkAccessEnabled),
+	}, false)
+}

--- a/resourcemanager/network/public_network_access.go
+++ b/resourcemanager/network/public_network_access.go
@@ -1,0 +1,20 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package network
+
+// PublicNetworkAccess specifies whether a given Azure Resource is publicly accessible (fully/partially) or
+// private.
+type PublicNetworkAccess string
+
+const (
+	// PublicNetworkAccessDisabled specifies that Public Network Access is Disabled.
+	PublicNetworkAccessDisabled PublicNetworkAccess = "Disabled"
+
+	// PublicNetworkAccessEnabled specifies that Public Network Access is Enabled.
+	PublicNetworkAccessEnabled PublicNetworkAccess = "Enabled"
+
+	// PublicNetworkAccessSecuredByPerimeter specifies that Public Network Access is controlled by
+	// the Network Security Perimeter.
+	PublicNetworkAccessSecuredByPerimeter PublicNetworkAccess = "SecuredByPerimeter"
+)


### PR DESCRIPTION
This allows us to consolidate onto this in time - and means that we have a single set of constants for this purpose