### PR TITLE
`recaser` - extend functionality and expose error handling for better utility

### DIFF
--- a/resourcemanager/recaser/recase.go
+++ b/resourcemanager/recaser/recase.go
@@ -5,10 +5,10 @@ package recaser
 
 import (
 	"fmt"
-	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"regexp"
 	"strings"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 

--- a/resourcemanager/recaser/recase.go
+++ b/resourcemanager/recaser/recase.go
@@ -74,7 +74,7 @@ func reCaseKnownId(input string, ids map[string]resourceids.ResourceId) (*string
 				}
 				// We have some cases where an erroneous trailing '/' causes problems. These may be data errors in specs, or API responses.
 				// Either way, we can try and compensate for it.
-				if id = knownResourceIds[strings.TrimPrefix(trimmedKey, strings.TrimSuffix(v, "/"))]; id != nil {
+				if id = knownResourceIds[strings.TrimPrefix(*key, strings.TrimSuffix(v, "/"))]; id != nil {
 					var parseError error
 					output, parseError = parseId(id, input)
 					if parseError != nil {
@@ -178,4 +178,28 @@ func PotentialScopeValues() []string {
 	}
 
 	return result
+}
+
+// ResourceIdTypeFromResourceId takes a Azure Resource ID as a string and attempts to return the corresponding
+// resourceids.ResourceId type.
+func ResourceIdTypeFromResourceId(input string) resourceids.ResourceId {
+	key, ok := buildInputKey(input)
+	if ok {
+		id := knownResourceIds[*key]
+		if id != nil {
+			return id
+		} else {
+			for _, v := range PotentialScopeValues() {
+				trimmedKey := strings.TrimPrefix(*key, v)
+				if id = knownResourceIds[trimmedKey]; id != nil {
+					return id
+				}
+				if id = knownResourceIds[strings.TrimPrefix(*key, strings.TrimSuffix(v, "/"))]; id != nil {
+					return id
+				}
+			}
+		}
+	}
+
+	return nil
 }

--- a/resourcemanager/recaser/recase.go
+++ b/resourcemanager/recaser/recase.go
@@ -5,6 +5,7 @@ package recaser
 
 import (
 	"fmt"
+	"reflect"
 	"regexp"
 	"strings"
 
@@ -193,15 +194,18 @@ func ResourceIdTypeFromResourceId(input string) resourceids.ResourceId {
 	if ok {
 		id := knownResourceIds[*key]
 		if id != nil {
-			return id
+			result := reflect.New(reflect.TypeOf(id).Elem())
+			return result.Interface().(resourceids.ResourceId)
 		} else {
 			for _, v := range PotentialScopeValues() {
 				trimmedKey := strings.TrimPrefix(*key, v)
 				if id = knownResourceIds[trimmedKey]; id != nil {
-					return id
+					result := reflect.New(reflect.TypeOf(id).Elem())
+					return result.Interface().(resourceids.ResourceId)
 				}
 				if id = knownResourceIds[strings.TrimPrefix(*key, strings.TrimSuffix(v, "/"))]; id != nil {
-					return id
+					result := reflect.New(reflect.TypeOf(id).Elem())
+					return result.Interface().(resourceids.ResourceId)
 				}
 			}
 		}

--- a/resourcemanager/recaser/recase.go
+++ b/resourcemanager/recaser/recase.go
@@ -19,18 +19,22 @@ func ReCase(input string) string {
 // reCaseWithIds tries to determine the type of Resource ID defined in `input` to be able to re-case it based on an input list of Resource IDs
 func reCaseWithIds(input string, ids map[string]resourceids.ResourceId) string {
 	output := input
-	recased := false
+	reCased := false
+	var parseError error
 
 	key, ok := buildInputKey(input)
 	if ok {
 		id := ids[*key]
 		if id != nil {
-			output, recased = parseId(id, input)
+			output, parseError = parseId(id, input)
+			if parseError == nil {
+				reCased = true
+			}
 		}
 	}
 
-	// if we can't find a matching id recase these known segments
-	if !recased {
+	// if we can't find a matching id re-case these known segments
+	if !reCased {
 
 		segmentsToFix := []string{
 			"/subscriptions/",
@@ -47,8 +51,32 @@ func reCaseWithIds(input string, ids map[string]resourceids.ResourceId) string {
 	return output
 }
 
+func RecaseKnownId(input string) (*string, error) {
+	return reCaseKnownId(input, knownResourceIds)
+}
+
+func reCaseKnownId(input string, ids map[string]resourceids.ResourceId) (*string, error) {
+	output := input
+
+	key, ok := buildInputKey(input)
+	if ok {
+		id := ids[*key]
+		if id != nil {
+			var parseError error
+			output, parseError = parseId(id, input)
+			if parseError != nil {
+				return &output, fmt.Errorf("fixing case for ID '%s': %+v", input, parseError)
+			}
+		}
+	} else {
+		return nil, fmt.Errorf("could not determine ID type for '%s', or ID type not supported", input)
+	}
+
+	return &output, nil
+}
+
 // parseId uses the specified ResourceId to parse the input and returns the id string with correct casing
-func parseId(id resourceids.ResourceId, input string) (string, bool) {
+func parseId(id resourceids.ResourceId, input string) (string, error) {
 
 	// we need to take a local copy of id to work against else we're mutating the original
 	localId := id
@@ -56,15 +84,15 @@ func parseId(id resourceids.ResourceId, input string) (string, bool) {
 	parser := resourceids.NewParserFromResourceIdType(localId)
 	parsed, err := parser.Parse(input, true)
 	if err != nil {
-		return input, false
+		return input, err
 	}
 
 	if err = id.FromParseResult(*parsed); err != nil {
-		return input, false
+		return input, err
 	}
 	input = id.ID()
 
-	return input, true
+	return input, err
 }
 
 // fixSegment searches the input id string for a specified segment case-insensitively
@@ -81,9 +109,13 @@ func fixSegment(input, segment string) string {
 // so it can be used as a key to extract the correct id from knownResourceIds
 func buildInputKey(input string) (*string, bool) {
 
-	// don't attempt to build a key if this isn't a standard resource id
+	// Attempt to determine if this is just missing a leading slash and prepend it if it seems to be
 	if !strings.HasPrefix(input, "/") {
-		return nil, false
+		if len(input) == 0 || !strings.Contains(input, "/") {
+			return nil, false
+		}
+
+		input = "/" + input
 	}
 
 	output := ""

--- a/resourcemanager/recaser/recase.go
+++ b/resourcemanager/recaser/recase.go
@@ -18,7 +18,9 @@ func ReCase(input string) string {
 }
 
 // reCaseWithIds tries to determine the type of Resource ID defined in `input` to be able to re-case it based on an input list of Resource IDs
-// this is a "best-effort" function and cn return the input unmodified.
+// this is a "best-effort" function and can return the input unmodified. Functionality of this method is intended to be
+// limited to resource IDs that have been registered with the package via the RegisterResourceId() function at init.
+// However, some common static segments are corrected even when a corresponding ID type is not present.
 func reCaseWithIds(input string, ids map[string]resourceids.ResourceId) string {
 	result, err := reCaseKnownId(input, ids)
 	if err == nil {
@@ -42,7 +44,10 @@ func reCaseWithIds(input string, ids map[string]resourceids.ResourceId) string {
 	return output
 }
 
-func RecaseKnownId(input string) (*string, error) {
+// ReCaseKnownId attempts to correct the casing on the static segments of an Azure resourceId. Functionality of this
+// method is intended to be limited to resource IDs that have been registered with the package via the
+// RegisterResourceId() function at init.
+func ReCaseKnownId(input string) (*string, error) {
 	return reCaseKnownId(input, knownResourceIds)
 }
 
@@ -181,7 +186,8 @@ func PotentialScopeValues() []string {
 }
 
 // ResourceIdTypeFromResourceId takes a Azure Resource ID as a string and attempts to return the corresponding
-// resourceids.ResourceId type.
+// resourceids.ResourceId type. If a matching resourceId is not found in the supported/registered resourceId types then
+// a `nil` value is returned.
 func ResourceIdTypeFromResourceId(input string) resourceids.ResourceId {
 	key, ok := buildInputKey(input)
 	if ok {

--- a/resourcemanager/recaser/recaser_test.go
+++ b/resourcemanager/recaser/recaser_test.go
@@ -132,6 +132,15 @@ func TestReCaserWithOddNumberOfSegmentsAndIncorrectCasing(t *testing.T) {
 	}
 }
 
+func TestReCaserWithScopedID(t *testing.T) {
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Chaos/targets/target1"
+	actual := reCaseWithIds("/SubsCriptions/12345678-1234-9876-4563-123456789012/resourcegroups/resGroup1/providers/microsoft.chaos/Targets/target1", getTestIds())
+
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
 func TestReCaserWithURIAndCorrectCasing(t *testing.T) {
 	expected := "https://management.azure.com:80/subscriptions/12345"
 	actual := reCaseWithIds("https://management.azure.com:80/subscriptions/12345", getTestIds())
@@ -161,8 +170,9 @@ func TestReCaserWithDataPlaneURI(t *testing.T) {
 
 func getTestIds() map[string]resourceids.ResourceId {
 	return map[string]resourceids.ResourceId{
-		strings.ToLower(commonids.AppServiceId{}.ID()):      &commonids.AppServiceId{},
-		strings.ToLower(commonids.AvailabilitySetId{}.ID()): &commonids.AvailabilitySetId{},
-		strings.ToLower(commonids.BotServiceId{}.ID()):      &commonids.BotServiceId{},
+		strings.ToLower(commonids.AppServiceId{}.ID()):        &commonids.AppServiceId{},
+		strings.ToLower(commonids.AvailabilitySetId{}.ID()):   &commonids.AvailabilitySetId{},
+		strings.ToLower(commonids.BotServiceId{}.ID()):        &commonids.BotServiceId{},
+		strings.ToLower(commonids.ChaosStudioTargetId{}.ID()): &commonids.ChaosStudioTargetId{},
 	}
 }

--- a/resourcemanager/recaser/recaser_test.go
+++ b/resourcemanager/recaser/recaser_test.go
@@ -4,6 +4,7 @@
 package recaser
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
@@ -174,5 +175,13 @@ func getTestIds() map[string]resourceids.ResourceId {
 		strings.ToLower(commonids.AvailabilitySetId{}.ID()):   &commonids.AvailabilitySetId{},
 		strings.ToLower(commonids.BotServiceId{}.ID()):        &commonids.BotServiceId{},
 		strings.ToLower(commonids.ChaosStudioTargetId{}.ID()): &commonids.ChaosStudioTargetId{},
+	}
+}
+
+func TestResourceIdTypeFromResourceId(t *testing.T) {
+	for k, v := range getTestIds() {
+		if actual := ResourceIdTypeFromResourceId(k); !reflect.DeepEqual(v, actual) {
+			t.Fatalf("Expected %q but got %q", v, actual)
+		}
 	}
 }

--- a/resourcemanager/recaser/registration.go
+++ b/resourcemanager/recaser/registration.go
@@ -13,6 +13,15 @@ import (
 
 var knownResourceIds = make(map[string]resourceids.ResourceId)
 
+// KnownResourceIds returns the map of resource IDs that have been registered by each API imported via the
+// RegisterResourceId function. This is the case for all APIs generated via the Pandora project via init().
+// The keys for the map are the lower-cased ID strings with the user-specified segments
+// stripped out, leaving the path intact. Example:
+// "/subscriptions//resourceGroups//providers/Microsoft.BotService/botServices/"
+func KnownResourceIds() map[string]resourceids.ResourceId {
+	return knownResourceIds
+}
+
 var resourceIdsWriteLock = &sync.Mutex{}
 
 func init() {


### PR DESCRIPTION
This PR 
- adds basic support for dealing with scopes in IDs (limited to potential scopes from the registered ID Types)
- adds an accessor for the registered ID Types
- adds functionality to expose errors for consumers to make decisions based on returns
- adds support for getting the id type from a resource id string for registered IDs