### PR TITLE
Azure Zone: Add Optional Computed Schema

### DIFF
--- a/resourcemanager/commonschema/zone.go
+++ b/resourcemanager/commonschema/zone.go
@@ -56,11 +56,11 @@ func ZoneSingleComputed() *schema.Schema {
 	}
 }
 
-// ZoneSingleComputedOptional returns the schema used when a single Zones can be returned
-func ZoneSingleComputedOptional() *schema.Schema {
+// ZoneSingleOptionalComputed returns the schema used when a single Zones can be returned
+func ZoneSingleOptionalComputed() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeString,
-		Computed: true,
 		Optional: true,
+		Computed: true,
 	}
 }

--- a/resourcemanager/commonschema/zone.go
+++ b/resourcemanager/commonschema/zone.go
@@ -8,8 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-// NOTE: we intentionally don't have an Optional & Computed here for behavioural consistency.
-
 // ZoneSingleRequired returns the schema used when a single Zone must be specified
 func ZoneSingleRequired() *schema.Schema {
 	return &schema.Schema{

--- a/resourcemanager/commonschema/zone.go
+++ b/resourcemanager/commonschema/zone.go
@@ -56,7 +56,7 @@ func ZoneSingleComputed() *schema.Schema {
 	}
 }
 
-// ZoneSingleOptionalComputed returns the schema used when a single Zones can be returned
+// ZoneSingleOptionalComputed returns the schema used when a single Zone can be specified or a single Zone is returned when omitted
 func ZoneSingleOptionalComputed() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeString,

--- a/resourcemanager/commonschema/zone.go
+++ b/resourcemanager/commonschema/zone.go
@@ -55,3 +55,12 @@ func ZoneSingleComputed() *schema.Schema {
 		Computed: true,
 	}
 }
+
+// ZoneSingleComputedOptional returns the schema used when a single Zones can be returned
+func ZoneSingleComputedOptional() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeString,
+		Computed: true,
+		Optional: true,
+	}
+}


### PR DESCRIPTION
As per the group discussion and consensus, this PR adds a schema for `zone` that is `Optional` and `Computed`

## Testing

The result of running `make test`:

```sh
--- PASS: TestAzureEnvironmentNames (0.00s)
--- PASS: TestAccAzureEnvironmentByName (0.00s)
--- PASS: TestAccAzureEnvironmentByNameFromEndpoint (0.54s)
--- PASS: TestAccIsEnvironmentAzureStack (0.00s)
--- PASS: TestParseEventHubConnectionString (0.00s)
--- PASS: TestComputeEventHubSASToken (0.00s)
--- PASS: TestComputeEventHubSASConnectionString (0.00s)
--- PASS: TestComputeEventHubSASConnectionUrl (0.00s)
--- PASS: TestFrom_ListOfStrings (0.00s)
--- PASS: TestFrom_NilTypes (0.00s)
--- PASS: TestFrom_MapOfInterface (0.00s)
--- PASS: TestBadRequest_DroppedConnection (0.00s)
--- PASS: TestBadRequest_StatusCodes (0.00s)
--- PASS: TestConflict_DroppedConnection (0.00s)
--- PASS: TestConflict_StatusCodes (0.00s)
--- PASS: TestForbidden_DroppedConnection (0.00s)
--- PASS: TestForbidden_StatusCodes (0.00s)
--- PASS: TestNotFound_DroppedConnection (0.00s)
--- PASS: TestNotFound_StatusCodes (0.00s)
--- PASS: TestWasStatusCode_DroppedConnection (0.00s)
--- PASS: TestWasStatusCode_StatusCodes (0.00s)
--- PASS: TestNewAppServiceEnvironmentID (0.00s)
--- PASS: TestFormatAppServiceEnvironmentID (0.00s)
--- PASS: TestParseAppServiceEnvironmentID (0.00s)
--- PASS: TestParseAppServiceEnvironmentIDInsensitively (0.00s)
--- PASS: TestSegmentsForAppServiceEnvironmentId (0.00s)
--- PASS: TestNewAppServicePlanID (0.00s)
--- PASS: TestFormatAppServicePlanID (0.00s)
--- PASS: TestParseAppServicePlanID (0.00s)
--- PASS: TestParseAppServicePlanIDInsensitively (0.00s)
--- PASS: TestSegmentsForAppServicePlanId (0.00s)
--- PASS: TestNewAppServiceID (0.00s)
--- PASS: TestFormatAppServiceID (0.00s)
--- PASS: TestParseAppServiceID (0.00s)
--- PASS: TestParseAppServiceIDInsensitively (0.00s)
--- PASS: TestSegmentsForAppServiceId (0.00s)
--- PASS: TestNewAutomationCompilationJobID (0.00s)
--- PASS: TestFormatAutomationCompilationJobID (0.00s)
--- PASS: TestParseAutomationCompilationJobID (0.00s)
--- PASS: TestParseAutomationCompilationJobIDInsensitively (0.00s)
--- PASS: TestSegmentsForAutomationCompilationJobId (0.00s)
--- PASS: TestNewAvailabilitySetID (0.00s)
--- PASS: TestFormatAvailabilitySetID (0.00s)
--- PASS: TestParseAvailabilitySetID (0.00s)
--- PASS: TestParseAvailabilitySetIDInsensitively (0.00s)
--- PASS: TestSegmentsForAvailabilitySetId (0.00s)
--- PASS: TestNewBillingAccountCustomerID (0.00s)
--- PASS: TestFormatBillingAccountCustomerID (0.00s)
--- PASS: TestParseBillingAccountCustomerID (0.00s)
--- PASS: TestParseBillingAccountCustomerIDInsensitively (0.00s)
--- PASS: TestSegmentsForBillingAccountCustomerId (0.00s)
--- PASS: TestNewBillingAccountInvoiceSectionID (0.00s)
--- PASS: TestFormatBillingAccountInvoiceSectionID (0.00s)
--- PASS: TestParseBillingAccountInvoiceSectionID (0.00s)
--- PASS: TestParseBillingAccountInvoiceSectionIDInsensitively (0.00s)
--- PASS: TestSegmentsForBillingAccountInvoiceSectionId (0.00s)
--- PASS: TestNewBillingEnrollmentAccountID (0.00s)
--- PASS: TestFormatBillingEnrollmentAccountID (0.00s)
--- PASS: TestParseBillingEnrollmentAccountID (0.00s)
--- PASS: TestParseBillingEnrollmentAccountIDInsensitively (0.00s)
--- PASS: TestSegmentsForBillingEnrollmentAccountId (0.00s)
--- PASS: TestNewBotServiceChannelID (0.00s)
--- PASS: TestFormatBotServiceChannelID (0.00s)
--- PASS: TestParseBotServiceChannelID (0.00s)
--- PASS: TestParseBotServiceChannelIDInsensitively (0.00s)
--- PASS: TestSegmentsForBotServiceChannelId (0.00s)
--- PASS: TestNewBotServiceID (0.00s)
--- PASS: TestFormatBotServiceID (0.00s)
--- PASS: TestParseBotServiceID (0.00s)
--- PASS: TestParseBotServiceIDInsensitively (0.00s)
--- PASS: TestSegmentsForBotServiceId (0.00s)
--- PASS: TestNewChaosStudioCapabilityId (0.00s)
--- PASS: TestFormatChaosStudioCapabilityId (0.00s)
--- PASS: TestParseChaosStudioCapabilityId (0.00s)
--- PASS: TestParseChaosStudioCapabilityIdInsensitively (0.00s)
--- PASS: TestSegmentsForChaosStudioCapabilityId (0.00s)
--- PASS: TestNewChaosStudioTargetId (0.00s)
--- PASS: TestFormatChaosStudioTargetId (0.00s)
--- PASS: TestParseChaosStudioTargetId (0.00s)
--- PASS: TestParseChaosStudioTargetIdInsensitively (0.00s)
--- PASS: TestSegmentsForChaosStudioTargetId (0.00s)
--- PASS: TestNewCloudServicesIPConfigurationID (0.00s)
--- PASS: TestFormatCloudServicesIPConfigurationID (0.00s)
--- PASS: TestParseCloudServicesIPConfigurationID (0.00s)
--- PASS: TestParseCloudServicesIPConfigurationIDInsensitively (0.00s)
--- PASS: TestSegmentsForCloudServicesIPConfigurationId (0.00s)
--- PASS: TestNewCloudServicesPublicIPAddressID (0.00s)
--- PASS: TestFormatCloudServicesPublicIPAddressID (0.00s)
--- PASS: TestParseCloudServicesPublicIPAddressID (0.00s)
--- PASS: TestParseCloudServicesPublicIPAddressIDInsensitively (0.00s)
--- PASS: TestSegmentsForCloudServicesPublicIPAddressId (0.00s)
--- PASS: TestNewCommunityGalleryImageID (0.00s)
--- PASS: TestFormatCommunityGalleryImageID (0.00s)
--- PASS: TestParseCommunityGalleryImageID (0.00s)
--- PASS: TestParseCommunityGalleryImageIDInsensitively (0.00s)
--- PASS: TestSegmentsForCommunityGalleryImageId (0.00s)
--- PASS: TestNewCommunityGalleryImageVersionID (0.00s)
--- PASS: TestFormatCommunityGalleryImageVersionID (0.00s)
--- PASS: TestParseCommunityGalleryImageVersionID (0.00s)
--- PASS: TestParseCommunityGalleryImageVersionIDInsensitively (0.00s)
--- PASS: TestSegmentsForCommunityGalleryImageVersionId (0.00s)
--- PASS: TestNewCompositeResourceID (0.00s)
--- PASS: TestCompositeResourceID (0.00s)
--- PASS: TestParseCompositeResourceIDInsensitively (0.00s)
--- PASS: TestCompositeResourceIDNumberOfIDsErrors (0.00s)
--- PASS: TestCompositeResourceIDInvalidIDs (0.00s)
--- PASS: TestNewDedicatedHostGroupID (0.00s)
--- PASS: TestFormatDedicatedHostGroupID (0.00s)
--- PASS: TestParseHostGroupID (0.00s)
--- PASS: TestParseHostGroupIDInsensitively (0.00s)
--- PASS: TestSegmentsForDedicatedHostGroupId (0.00s)
--- PASS: TestNewDedicatedHostID (0.00s)
--- PASS: TestFormatDedicatedHostID (0.00s)
--- PASS: TestParseDedicatedHostID (0.00s)
--- PASS: TestParseDedicatedHostIDInsensitively (0.00s)
--- PASS: TestSegmentsForDedicatedHostId (0.00s)
--- PASS: TestNewDevCenterID (0.00s)
--- PASS: TestFormatDevCenterID (0.00s)
--- PASS: TestParseDevCenterID (0.00s)
--- PASS: TestParseDevCenterIDInsensitively (0.00s)
--- PASS: TestValidateDevCenterID (0.00s)
--- PASS: TestNewDiskEncryptionSetID (0.00s)
--- PASS: TestFormatDiskEncryptionSetID (0.00s)
--- PASS: TestParseDiskEncryptionSetID (0.00s)
--- PASS: TestParseDiskEncryptionSetIDInsensitively (0.00s)
--- PASS: TestSegmentsForDiskEncryptionSetId (0.00s)
--- PASS: TestNewExpressRouteCircuitPeeringID (0.00s)
--- PASS: TestFormatExpressRouteCircuitPeeringID (0.00s)
--- PASS: TestParseExpressRouteCircuitPeeringID (0.00s)
--- PASS: TestParseExpressRouteCircuitPeeringIDInsensitively (0.00s)
--- PASS: TestSegmentsForExpressRouteCircuitPeeringId (0.00s)
--- PASS: TestNewHDInsightClusterID (0.00s)
--- PASS: TestFormatHDInsightClusterID (0.00s)
--- PASS: TestParseHDInsightClusterID (0.00s)
--- PASS: TestParseHDInsightClusterIDInsensitively (0.00s)
--- PASS: TestSegmentsForHDInsightClusterId (0.00s)
--- PASS: TestNewHyperVSiteJobID (0.00s)
--- PASS: TestFormatHyperVSiteJobID (0.00s)
--- PASS: TestParseHyperVSiteJobID (0.00s)
--- PASS: TestParseHyperVSiteJobIDInsensitively (0.00s)
--- PASS: TestSegmentsForHyperVSiteJobId (0.00s)
--- PASS: TestNewHyperVSiteMachineID (0.00s)
--- PASS: TestFormatHyperVSiteMachineID (0.00s)
--- PASS: TestParseHyperVSiteMachineID (0.00s)
--- PASS: TestParseHyperVSiteMachineIDInsensitively (0.00s)
--- PASS: TestSegmentsForHyperVSiteMachineId (0.00s)
--- PASS: TestNewHyperVSiteRunAsAccountID (0.00s)
--- PASS: TestFormatHyperVSiteRunAsAccountID (0.00s)
--- PASS: TestParseHyperVSiteRunAsAccountID (0.00s)
--- PASS: TestParseHyperVSiteRunAsAccountIDInsensitively (0.00s)
--- PASS: TestSegmentsForHyperVSiteRunAsAccountId (0.00s)
--- PASS: TestNewKeyVaultKeyID (0.00s)
--- PASS: TestFormatKeyVaultKeyID (0.00s)
--- PASS: TestParseKeyVaultKeyID (0.00s)
--- PASS: TestParseKeyVaultKeyIDInsensitively (0.00s)
--- PASS: TestSegmentsForKeyVaultKeyId (0.00s)
--- PASS: TestNewKeyVaultKeyVersionID (0.00s)
--- PASS: TestFormatKeyVaultKeyVersionID (0.00s)
--- PASS: TestParseKeyVaultKeyVersionID (0.00s)
--- PASS: TestParseKeyVaultKeyVersionIDInsensitively (0.00s)
--- PASS: TestSegmentsForKeyVaultKeyVersionId (0.00s)
--- PASS: TestNewKeyVaultPrivateEndpointConnectionID (0.00s)
--- PASS: TestFormatKeyVaultPrivateEndpointConnectionID (0.00s)
--- PASS: TestParseKeyVaultPrivateEndpointConnectionID (0.00s)
--- PASS: TestParseKeyVaultPrivateEndpointConnectionIDInsensitively (0.00s)
--- PASS: TestSegmentsForKeyVaultPrivateEndpointConnectionId (0.00s)
--- PASS: TestNewKeyVaultID (0.00s)
--- PASS: TestFormatKeyVaultID (0.00s)
--- PASS: TestParseKeyVaultID (0.00s)
--- PASS: TestParseKeyVaultIDInsensitively (0.00s)
--- PASS: TestSegmentsForKeyVaultId (0.00s)
--- PASS: TestNewKubernetesClusterID (0.00s)
--- PASS: TestFormatKubernetesClusterID (0.00s)
--- PASS: TestParseKubernetesClusterID (0.00s)
--- PASS: TestParseKubernetesClusterIDInsensitively (0.00s)
--- PASS: TestSegmentsForKubernetesClusterId (0.00s)
--- PASS: TestNewKubernetesFleetID (0.00s)
--- PASS: TestFormatKubernetesFleetID (0.00s)
--- PASS: TestParseKubernetesFleetID (0.00s)
--- PASS: TestParseKubernetesFleetIDInsensitively (0.00s)
--- PASS: TestSegmentsForKubernetesFleetId (0.00s)
--- PASS: TestNewKustoClusterID (0.00s)
--- PASS: TestFormatKustoClusterID (0.00s)
--- PASS: TestParseKustoClusterID (0.00s)
--- PASS: TestParseKustoClusterIDInsensitively (0.00s)
--- PASS: TestSegmentsForKustoClusterId (0.00s)
--- PASS: TestNewKustoDatabaseID (0.00s)
--- PASS: TestFormatKustoDatabaseID (0.00s)
--- PASS: TestParseKustoDatabaseID (0.00s)
--- PASS: TestParseKustoDatabaseIDInsensitively (0.00s)
--- PASS: TestSegmentsForKustoDatabaseId (0.00s)
--- PASS: TestNewManagedDiskID (0.00s)
--- PASS: TestFormatManagedDiskID (0.00s)
--- PASS: TestParseManagedDiskID (0.00s)
--- PASS: TestParseManagedDiskIDInsensitively (0.00s)
--- PASS: TestSegmentsForManagedDiskId (0.00s)
--- PASS: TestNewManagementGroupID (0.00s)
--- PASS: TestFormatManagementGroupID (0.00s)
--- PASS: TestParseManagementGroupID (0.00s)
--- PASS: TestParseManagementGroupIDInsensitively (0.00s)
--- PASS: TestSegmentsForManagementGroupId (0.00s)
--- PASS: TestNewNetworkInterfaceIPConfigurationID (0.00s)
--- PASS: TestFormatNetworkInterfaceIPConfigurationID (0.00s)
--- PASS: TestParseNetworkInterfaceIPConfigurationID (0.00s)
--- PASS: TestParseNetworkInterfaceIPConfigurationIDInsensitively (0.00s)
--- PASS: TestSegmentsForNetworkInterfaceIPConfigurationId (0.00s)
--- PASS: TestNewNetworkInterfaceID (0.00s)
--- PASS: TestFormatNetworkInterfaceID (0.00s)
--- PASS: TestParseNetworkInterfaceID (0.00s)
--- PASS: TestParseNetworkInterfaceIDInsensitively (0.00s)
--- PASS: TestSegmentsForNetworkInterfaceId (0.00s)
--- PASS: TestNewProvisioningServiceID (0.00s)
--- PASS: TestFormatProvisioningServiceID (0.00s)
--- PASS: TestParseProvisioningServiceID (0.00s)
--- PASS: TestParseProvisioningServiceIDInsensitively (0.00s)
--- PASS: TestSegmentsForProvisioningServiceId (0.00s)
--- PASS: TestNewPublicIPAddressID (0.00s)
--- PASS: TestFormatPublicIPAddressID (0.00s)
--- PASS: TestParsePublicIPAddressID (0.00s)
--- PASS: TestParsePublicIPAddressIDInsensitively (0.00s)
--- PASS: TestSegmentsForPublicIPAddressId (0.00s)
--- PASS: TestNewResourceGroupID (0.00s)
--- PASS: TestFormatResourceGroupID (0.00s)
--- PASS: TestParseResourceGroupID (0.00s)
--- PASS: TestParseResourceGroupIDInsensitively (0.00s)
--- PASS: TestSegmentsForResourceGroupId (0.00s)
--- PASS: TestNewScopeID (0.00s)
--- PASS: TestFormatScopeID (0.00s)
--- PASS: TestParseScopeID (0.00s)
--- PASS: TestParseScopeIDInsensitively (0.00s)
--- PASS: TestSegmentsForScopeId (0.00s)
--- PASS: TestNewSharedImageGalleryID (0.00s)
--- PASS: TestFormatSharedImageGalleryID (0.00s)
--- PASS: TestParseSharedImageGalleryID (0.00s)
--- PASS: TestParseSharedImageGalleryIDInsensitively (0.00s)
--- PASS: TestValidateSharedImageGalleryID (0.00s)
--- PASS: TestNewSpringCloudServiceID (0.00s)
--- PASS: TestFormatSpringCloudServiceID (0.00s)
--- PASS: TestParseSpringID (0.00s)
--- PASS: TestParseSpringIDInsensitively (0.00s)
--- PASS: TestSegmentsForSpringId (0.00s)
--- PASS: TestNewSqlDatabaseID (0.00s)
--- PASS: TestFormatSqlDatabaseID (0.00s)
--- PASS: TestParseSqlDatabaseID (0.00s)
--- PASS: TestParseSqlDatabaseIDInsensitively (0.00s)
--- PASS: TestSegmentsForSqlDatabaseId (0.00s)
--- PASS: TestNewSqlElasticPoolID (0.00s)
--- PASS: TestFormatSqlElasticPoolID (0.00s)
--- PASS: TestParseSqlElasticPoolID (0.00s)
--- PASS: TestParseSqlElasticPoolIDInsensitively (0.00s)
--- PASS: TestSegmentsForSqlElasticPoolId (0.00s)
--- PASS: TestNewSqlManagedInstanceDatabaseID (0.00s)
--- PASS: TestFormatSqlManagedInstanceDatabaseID (0.00s)
--- PASS: TestParseSqlManagedInstanceDatabaseID (0.00s)
--- PASS: TestParseSqlManagedInstanceDatabaseIDInsensitively (0.00s)
--- PASS: TestSegmentsForSqlManagedInstanceDatabaseId (0.00s)
--- PASS: TestNewManagedInstanceID (0.00s)
--- PASS: TestFormatManagedInstanceID (0.00s)
--- PASS: TestParseManagedInstanceID (0.00s)
--- PASS: TestParseManagedInstanceIDInsensitively (0.00s)
--- PASS: TestSegmentsForManagedInstanceId (0.00s)
--- PASS: TestNewSqlServerID (0.00s)
--- PASS: TestFormatSqlServerID (0.00s)
--- PASS: TestParseSqlServerID (0.00s)
--- PASS: TestParseSqlServerIDInsensitively (0.00s)
--- PASS: TestSegmentsForSqlServerId (0.00s)
--- PASS: TestNewStorageAccountID (0.00s)
--- PASS: TestFormatStorageAccountID (0.00s)
--- PASS: TestParseStorageAccountID (0.00s)
--- PASS: TestParseStorageAccountIDInsensitively (0.00s)
--- PASS: TestSegmentsForStorageAccountId (0.00s)
--- PASS: TestNewStorageContainerID (0.00s)
--- PASS: TestFormatStorageContainerID (0.00s)
--- PASS: TestParseStorageContainerID (0.00s)
--- PASS: TestParseStorageContainerIDInsensitively (0.00s)
--- PASS: TestSegmentsForStorageContainerId (0.00s)
--- PASS: TestNewSubnetID (0.00s)
--- PASS: TestFormatSubnetID (0.00s)
--- PASS: TestParseSubnetID (0.00s)
--- PASS: TestParseSubnetIDInsensitively (0.00s)
--- PASS: TestSegmentsForSubnetId (0.00s)
--- PASS: TestNewSubscriptionID (0.00s)
--- PASS: TestFormatSubscriptionID (0.00s)
--- PASS: TestParseSubscriptionID (0.00s)
--- PASS: TestParseSubscriptionIDInsensitively (0.00s)
--- PASS: TestSegmentsForSubscriptionId (0.00s)
--- PASS: TestNewUserAssignedIdentityID (0.00s)
--- PASS: TestFormatUserAssignedIdentityID (0.00s)
--- PASS: TestParseUserAssignedIdentityID (0.00s)
--- PASS: TestParseUserAssignedIdentityIDInsensitively (0.00s)
--- PASS: TestSegmentsForUserAssignedIdentityId (0.00s)
--- PASS: TestNewVirtualHubBGPConnectionID (0.00s)
--- PASS: TestFormatVirtualHubBGPConnectionID (0.00s)
--- PASS: TestParseVirtualHubBGPConnectionID (0.00s)
--- PASS: TestParseVirtualHubBGPConnectionIDInsensitively (0.00s)
--- PASS: TestSegmentsForVirtualHubBGPConnectionId (0.00s)
--- PASS: TestNewVirtualHubIPConfigurationID (0.00s)
--- PASS: TestFormatVirtualHubIPConfigurationID (0.00s)
--- PASS: TestParseVirtualHubIPConfigurationID (0.00s)
--- PASS: TestParseVirtualHubIPConfigurationIDInsensitively (0.00s)
--- PASS: TestSegmentsForVirtualHubIPConfigurationId (0.00s)
--- PASS: TestNewVirtualMachineScaleSetIPConfigurationID (0.00s)
--- PASS: TestFormatVirtualMachineScaleSetIPConfigurationID (0.00s)
--- PASS: TestParseVirtualMachineScaleSetIPConfigurationID (0.00s)
--- PASS: TestParseVirtualMachineScaleSetIPConfigurationIDInsensitively (0.00s)
--- PASS: TestSegmentsForVirtualMachineScaleSetIPConfigurationId (0.00s)
--- PASS: TestNewVirtualMachineScaleSetNetworkInterfaceID (0.00s)
--- PASS: TestFormatVirtualMachineScaleSetNetworkInterfaceID (0.00s)
--- PASS: TestParseVirtualMachineScaleSetNetworkInterfaceID (0.00s)
--- PASS: TestParseVirtualMachineScaleSetNetworkInterfaceIDInsensitively (0.00s)
--- PASS: TestSegmentsForVirtualMachineScaleSetNetworkInterfaceId (0.00s)
--- PASS: TestNewVirtualMachineScaleSetPublicIPAddressID (0.00s)
--- PASS: TestFormatVirtualMachineScaleSetPublicIPAddressID (0.00s)
--- PASS: TestParseVirtualMachineScaleSetPublicIPAddressID (0.00s)
--- PASS: TestParseVirtualMachineScaleSetPublicIPAddressIDInsensitively (0.00s)
--- PASS: TestSegmentsForVirtualMachineScaleSetPublicIPAddressId (0.00s)
--- PASS: TestNewVirtualMachineScaleSetID (0.00s)
--- PASS: TestFormatVirtualMachineScaleSetID (0.00s)
--- PASS: TestParseVirtualMachineScaleSetID (0.00s)
--- PASS: TestParseVirtualMachineScaleSetIDInsensitively (0.00s)
--- PASS: TestSegmentsForVirtualMachineScaleSetId (0.00s)
--- PASS: TestNewVirtualMachineID (0.00s)
--- PASS: TestFormatVirtualMachineID (0.00s)
--- PASS: TestParseVirtualMachineID (0.00s)
--- PASS: TestParseVirtualMachineIDInsensitively (0.00s)
--- PASS: TestSegmentsForVirtualMachineId (0.00s)
--- PASS: TestNewVirtualNetworkID (0.00s)
--- PASS: TestFormatVirtualNetworkID (0.00s)
--- PASS: TestParseVirtualNetworkID (0.00s)
--- PASS: TestParseVirtualNetworkIDInsensitively (0.00s)
--- PASS: TestSegmentsForVirtualNetworkId (0.00s)
--- PASS: TestNewVirtualRouterPeeringID (0.00s)
--- PASS: TestFormatVirtualRouterPeeringID (0.00s)
--- PASS: TestParseVirtualRouterPeeringID (0.00s)
--- PASS: TestParseVirtualRouterPeeringIDInsensitively (0.00s)
--- PASS: TestSegmentsForVirtualRouterPeeringId (0.00s)
--- PASS: TestNewVirtualWANP2SVPNGatewayID (0.00s)
--- PASS: TestFormatVirtualWANP2SVPNGatewayID (0.00s)
--- PASS: TestParseVirtualWANP2SVPNGatewayID (0.00s)
--- PASS: TestParseVirtualWANP2SVPNGatewayIDInsensitively (0.00s)
--- PASS: TestSegmentsForVirtualWANP2SVPNGatewayId (0.00s)
--- PASS: TestNewVMwareSiteJobID (0.00s)
--- PASS: TestFormatVMwareSiteJobID (0.00s)
--- PASS: TestParseVMwareSiteJobID (0.00s)
--- PASS: TestParseVMwareSiteJobIDInsensitively (0.00s)
--- PASS: TestSegmentsForVMwareSiteJobId (0.00s)
--- PASS: TestNewVMwareSiteMachineID (0.00s)
--- PASS: TestFormatVMwareSiteMachineID (0.00s)
--- PASS: TestParseVMwareSiteMachineID (0.00s)
--- PASS: TestParseVMwareSiteMachineIDInsensitively (0.00s)
--- PASS: TestSegmentsForVMwareSiteMachineId (0.00s)
--- PASS: TestNewVMwareSiteRunAsAccountID (0.00s)
--- PASS: TestFormatVMwareSiteRunAsAccountID (0.00s)
--- PASS: TestParseVMwareSiteRunAsAccountID (0.00s)
--- PASS: TestParseVMwareSiteRunAsAccountIDInsensitively (0.00s)
--- PASS: TestSegmentsForVMwareSiteRunAsAccountId (0.00s)
--- PASS: TestNewVPNConnectionID (0.00s)
--- PASS: TestFormatVPNConnectionID (0.00s)
--- PASS: TestParseVPNConnectionID (0.00s)
--- PASS: TestParseVPNConnectionIDInsensitively (0.00s)
--- PASS: TestSegmentsForVPNConnectionId (0.00s)
--- PASS: TestMarshalModel (0.00s)
--- PASS: TestUnmarshalModel (0.00s)
--- PASS: TestNormalizeLocation (0.00s)
--- PASS: TestNormalizeNilableLocation (0.00s)
--- PASS: TestLegacySystemUserAssignedListMarshal (0.00s)
--- PASS: TestLegacySystemUserAssignedMapMarshal (0.00s)
--- PASS: TestLegacySystemAndUserAssignedMapUnmarshal (0.00s)
--- PASS: TestSystemUserAssignedListMarshal (0.00s)
--- PASS: TestSystemUserAssignedMapMarshal (0.00s)
--- PASS: TestSystemAssignedMarshal (0.00s)
--- PASS: TestSystemOrUserAssignedListMarshal (0.00s)
--- PASS: TestSystemOrUserAssignedMapMarshal (0.00s)
--- PASS: TestUserAssignedListMarshal (0.00s)
--- PASS: TestUserAssignedMapMarshal (0.00s)
--- PASS: TestNormalizeLocation (0.00s)
--- PASS: TestNormalizeNilableLocation (0.00s)
--- PASS: TestEnhancedValidationDisabled (0.00s)
--- PASS: TestEnhancedValidationEnabled (0.00s)
--- PASS: TestReCaserWithIncorrectCasing (0.00s)
--- PASS: TestReCaserWithCorrectCasing (0.00s)
--- PASS: TestReCaserWithCorrectCasingResourceGroupId (0.00s)
--- PASS: TestReCaserWithIncorrectCasingResourceGroupId (0.00s)
--- PASS: TestReCaserWithUnknownId (0.00s)
--- PASS: TestReCaserWithUnkownIdContainingSubscriptions (0.00s)
--- PASS: TestReCaserWithUnkownIdContainingSubscriptionsAndResourceGroups (0.00s)
--- PASS: TestReCaserWithEmptyString (0.00s)
--- PASS: TestReCaserWithMultipleProviderSegmentsAndCorrectCasing (0.00s)
--- PASS: TestReCaserWithMultipleProviderSegmentsAndIncorrectCasing (0.00s)
--- PASS: TestReCaserWithIncompleteProviderSegments (0.00s)
--- PASS: TestReCaserWithOddNumberOfSegmentsAndCorrectCasing (0.00s)
--- PASS: TestReCaserWithOddNumberOfSegmentsAndIncorrectCasing (0.00s)
--- PASS: TestReCaserWithScopedID (0.00s)
--- PASS: TestReCaserWithURIAndCorrectCasing (0.00s)
--- PASS: TestReCaserWithURIAndIncorrectCasing (0.00s)
--- PASS: TestReCaserWithDataPlaneURI (0.00s)
--- PASS: TestResourceIdTypeFromResourceId (0.00s)
--- PASS: TestValidateResourceGroupName (0.00s)
--- PASS: TestMatch (0.00s)
--- PASS: TestMatch_Insensitive (0.00s)
--- PASS: TestNumberOfSegmentsDidntMatchError_CommonIdAllMissing (0.00s)
--- PASS: TestNumberOfSegmentsDidntMatchError_CommonIdMissingSegment (0.00s)
--- PASS: TestSegmentNotSpecifiedError_CommonId (0.00s)
--- PASS: TestSegmentNotSpecifiedError_MissingSegment (0.00s)
--- PASS: TestSegmentNotSpecifiedError_Constant (0.00s)
--- PASS: TestSegmentNotSpecifiedError_ResourceGroup (0.00s)
--- PASS: TestSegmentNotSpecifiedError_ResourceProvider (0.00s)
--- PASS: TestSegmentNotSpecifiedError_Scope (0.00s)
--- PASS: TestSegmentNotSpecifiedError_Static (0.00s)
--- PASS: TestSegmentNotSpecifiedError_SubscriptionId (0.00s)
--- PASS: TestSegmentNotSpecifiedError_UserSpecified (0.00s)
--- PASS: TestSegmentNotSpecifiedError_UnknownType (0.00s)
--- PASS: TestParseEmptyId (0.00s)
--- PASS: TestParseStaticId (0.00s)
--- PASS: TestParseResourceGroupId (0.00s)
--- PASS: TestParseVirtualMachineId (0.00s)
--- PASS: TestParseVirtualMachineExtensionId (0.00s)
--- PASS: TestParseAdvancedThreatProtectionId (0.00s)
--- PASS: TestParseIdContainingAConstant (0.00s)
--- PASS: TestParseIdContainingAScopePrefix (0.00s)
--- PASS: TestParseIdContainingAScopeSuffix (0.00s)
--- PASS: TestParseIdContainingAScopeEitherEnd (0.00s)
--- PASS: TestParseIdContainingJustAScope (0.00s)
--- PASS: TestValidateMaximumNumberOfTags (0.00s)
--- PASS: TestValidateTagMaxKeyLength (0.00s)
--- PASS: TestValidateTagMaxValueLength (0.00s)
--- PASS: TestParseStorageAccountConnectionString (0.00s)
--- PASS: TestComputeAccountSASToken (0.00s)
--- PASS: TestComputeContainerSASToken (0.00s)
--- PASS: TestComputeAccountSASConnectionString (0.00s)
--- PASS: TestComputeAccountSASConnectionUrlForType (0.00s)

```