### PR TITLE
Add notes about PR Labeler to add `release-once-merged` Label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,11 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# This file configures the "actions/labeler@v3" GitHub Action
+# https://github.com/actions/labeler
+
+# TODO: when the automatic build and push to provider tasks are working, the labeler action can be re-activated
+
 release-once-merged:
   - changed-files:
       - any-glob-to-any-file:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,13 @@
+name: "Labeler"
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Label PR"
+        uses: actions/labeler@v3
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,13 +1,15 @@
-name: "Labeler"
-on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+# TODO: when the automatic build and push to provider tasks are working, this labeler action can be re-activated
 
-jobs:
-  label:
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Label PR"
-        uses: actions/labeler@v3
-        with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+# name: "Labeler"
+# on:
+#   pull_request:
+#     types: [opened, synchronize, reopened]
+
+# jobs:
+#   label:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - name: "Label PR"
+#         uses: actions/labeler@v3
+#         with:
+#           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 ## `hashicorp/go-azure-helpers`
 
 This repository contains various helpers and wrappers for working with Azure - and contains a number of common types used in `hashicorp/go-azure-sdk`.
+
+### Release Process
+
+If you would like your changes to be built into a release once merged, add the `release-once-merged` label to your PR.
+
+If you would like the AzureRM Terraform Provider to be updated, add the `update-azurerm-after-release` label to your PR.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
 ## `hashicorp/go-azure-helpers`
 
 This repository contains various helpers and wrappers for working with Azure - and contains a number of common types used in `hashicorp/go-azure-sdk`.
-
-### Release Process
-
-If you would NOT like your changes to be built into a release once merged, remove the automatically added `release-once-merged` label from your PR.
-
-If you would like the AzureRM Terraform Provider to be updated once your PR is merged and released, add the `update-azurerm-after-release` label to your PR.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ This repository contains various helpers and wrappers for working with Azure - a
 
 ### Release Process
 
-If you would like your changes to be built into a release once merged, add the `release-once-merged` label to your PR.
+If you would NOT like your changes to be built into a release once merged, remove the automatically added `release-once-merged` label from your PR.
 
-If you would like the AzureRM Terraform Provider to be updated, add the `update-azurerm-after-release` label to your PR.
+If you would like the AzureRM Terraform Provider to be updated once your PR is merged and released, add the `update-azurerm-after-release` label to your PR.


### PR DESCRIPTION
This PR does the following:
- Adds a commented out Labeler GitHub Action that would add `release-once-merged` to PRs