### PR TITLE
add commonschema and validate func for tags with max elems

### DIFF
--- a/resourcemanager/commonschema/tags.go
+++ b/resourcemanager/commonschema/tags.go
@@ -41,6 +41,17 @@ func Tags() *schema.Schema {
 	}
 }
 
+func TagsWithMaximumElements(m int) *schema.Schema {
+	return &schema.Schema{
+		Type:         schema.TypeMap,
+		Optional:     true,
+		ValidateFunc: tags.ValidateWithMaximumElements(m),
+		Elem: &schema.Schema{
+			Type: schema.TypeString,
+		},
+	}
+}
+
 func TagsWithLowerCaseKeys() *schema.Schema {
 	return &schema.Schema{
 		Type:         schema.TypeMap,

--- a/resourcemanager/tags/validate.go
+++ b/resourcemanager/tags/validate.go
@@ -5,8 +5,9 @@ package tags
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func Validate(v interface{}, _ string) (warnings []string, errors []error) {

--- a/resourcemanager/tags/validate.go
+++ b/resourcemanager/tags/validate.go
@@ -68,6 +68,7 @@ func ValidateHasLowerCaseKeys(i interface{}, k string) (warnings []string, error
 	return warnings, errors
 }
 
+// nolint: staticcheck
 func ValidateWithMaximumElements(max int) schema.SchemaValidateFunc {
 	return func(v interface{}, _ string) (warnings []string, errors []error) {
 		tagsMap := v.(map[string]interface{})

--- a/resourcemanager/tags/validate.go
+++ b/resourcemanager/tags/validate.go
@@ -5,6 +5,7 @@ package tags
 
 import (
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"strings"
 )
 
@@ -65,6 +66,31 @@ func ValidateHasLowerCaseKeys(i interface{}, k string) (warnings []string, error
 	}
 
 	return warnings, errors
+}
+
+func ValidateWithMaximumElements(max int) schema.SchemaValidateFunc {
+	return func(v interface{}, _ string) (warnings []string, errors []error) {
+		tagsMap := v.(map[string]interface{})
+
+		if len(tagsMap) > max {
+			errors = append(errors, fmt.Errorf("a maximum of %d tags can be applied to this ARM resource", max))
+		}
+
+		for k, v := range tagsMap {
+			if len(k) > 512 {
+				errors = append(errors, fmt.Errorf("the maximum length for a tag key is 512 characters: %q is %d characters", k, len(k)))
+			}
+
+			value, err := tagValueToString(v)
+			if err != nil {
+				errors = append(errors, err)
+			} else if len(value) > 256 {
+				errors = append(errors, fmt.Errorf("the maximum length for a tag value is 256 characters: the value for %q is %d characters", k, len(value)))
+			}
+		}
+
+		return warnings, errors
+	}
 }
 
 func tagValueToString(v interface{}) (string, error) {


### PR DESCRIPTION
To support removal of the schema function in the `tags` within `terraform-provider-azurerm`