### PR TITLE
`resourceids` - support data plane scope prefixed IDs

### DIFF
--- a/resourcemanager/resourceids/parse.go
+++ b/resourcemanager/resourceids/parse.go
@@ -194,9 +194,7 @@ func (p Parser) Parse(input string, insensitively bool) (*ParseResult, error) {
 
 	if dataPlaneHasScopeAtStart {
 		uri = strings.TrimPrefix(uri, "fakeScope")
-		if strings.HasPrefix(uri, "/") {
-			uri = strings.TrimPrefix(uri, "/")
-		}
+		uri = strings.TrimPrefix(uri, "/")
 	}
 
 	for i, segment := range p.segments {
@@ -285,7 +283,7 @@ func (p Parser) parseScopeSegment(input string, insensitively bool) (*string, er
 		// 0 is the entire string, 1 will be the scope prefix, we can ignore the rest
 		values := r.FindStringSubmatch(input)
 		if len(values) < 2 {
-			return nil, fmt.Errorf("unable to find the scope prefix from the value %q with the regex %q", input, regexToUse)
+			continue
 		}
 		v := values[1]
 		if v == "" {
@@ -296,6 +294,7 @@ func (p Parser) parseScopeSegment(input string, insensitively bool) (*string, er
 		}
 		return &v, nil
 	}
+
 	return nil, fmt.Errorf("input %q does not match any supported scope pattern", input)
 }
 

--- a/resourcemanager/resourceids/parse.go
+++ b/resourcemanager/resourceids/parse.go
@@ -272,11 +272,9 @@ func (p Parser) parseScopePrefix(input, regexForNonScopeSegments string, insensi
 func (p Parser) parseScopeSegment(input, regexForNonScopeSegments string, insensitively bool) (*string, error) {
 	knownPatterns := []string{
 		`(subscriptions\/[^\/]+\/resourceGroups\/[^\/]+)`,
-		// `(subscriptions\/[^\/]+\/resourceGroups\/[^\/]+)\/`,
 		`providers/Microsoft.Management/managementGroups/[^\/]+`,
 	}
 	for _, regexToUse := range knownPatterns {
-		// TODO - if the ID contains more than 1 `providers` then the first is part of the scope so we need to consume it here *sigh*
 		if insensitively {
 			regexToUse = fmt.Sprintf("(?i)%s", regexToUse)
 		}

--- a/resourcemanager/resourceids/parse.go
+++ b/resourcemanager/resourceids/parse.go
@@ -159,7 +159,7 @@ func (p Parser) Parse(input string, insensitively bool) (*ParseResult, error) {
 		idPrefix = *prefix
 		parseResult.Parsed[p.segments[0].Name] = strings.TrimSuffix(*prefix, "/") // Trim the trailing / to match up to the ID builder value or we'll get a double
 		if dataPlaneHasScopeAtStart {
-			scope, err := p.parseScopeSegment(input, nonScopeComponentsRegex, insensitively)
+			scope, err := p.parseScopeSegment(input, insensitively)
 			if err != nil {
 				return nil, fmt.Errorf("parsing data plane scope: %+v", err)
 			}
@@ -269,7 +269,7 @@ func (p Parser) parseScopePrefix(input, regexForNonScopeSegments string, insensi
 	return &v, nil
 }
 
-func (p Parser) parseScopeSegment(input, regexForNonScopeSegments string, insensitively bool) (*string, error) {
+func (p Parser) parseScopeSegment(input string, insensitively bool) (*string, error) {
 	knownPatterns := []string{
 		`(subscriptions\/[^\/]+\/resourceGroups\/[^\/]+)`,
 		`providers/Microsoft.Management/managementGroups/[^\/]+`,

--- a/resourcemanager/resourceids/parse.go
+++ b/resourcemanager/resourceids/parse.go
@@ -94,11 +94,12 @@ func (p Parser) Parse(input string, insensitively bool) (*ParseResult, error) {
 	hasScopeAtStart := p.segments[0].Type == ScopeSegmentType
 	hasScopeAtEnd := p.segments[len(p.segments)-1].Type == ScopeSegmentType
 	hasDataPlaneBaseURIAtStart := p.segments[0].Type == DataPlaneBaseURISegmentType
+	dataPlaneHasScopeAtStart := p.segments[1].Type == ScopeSegmentType && hasDataPlaneBaseURIAtStart
 
 	// go through and build up a regex which will count for the `middle` components of the Resource ID
 	nonScopeComponentsRegex := ""
 	for i, segment := range p.segments {
-		if (i == 0 && hasScopeAtStart) || (i == len(p.segments)-1 && hasScopeAtEnd) {
+		if (i == 0 && hasScopeAtStart) || (i == len(p.segments)-1 && hasScopeAtEnd) || (i == 1 && dataPlaneHasScopeAtStart) {
 			continue
 		}
 
@@ -147,6 +148,8 @@ func (p Parser) Parse(input string, insensitively bool) (*ParseResult, error) {
 		parseResult.Parsed[p.segments[0].Name] = *prefix
 	}
 
+	uri := input
+
 	if hasDataPlaneBaseURIAtStart {
 		prefix, err := p.parseDataPlaneBaseURIPrefix(input)
 		if err != nil {
@@ -155,11 +158,20 @@ func (p Parser) Parse(input string, insensitively bool) (*ParseResult, error) {
 
 		idPrefix = *prefix
 		parseResult.Parsed[p.segments[0].Name] = strings.TrimSuffix(*prefix, "/") // Trim the trailing / to match up to the ID builder value or we'll get a double
+		if dataPlaneHasScopeAtStart {
+			scope, err := p.parseScopeSegment(input, nonScopeComponentsRegex, insensitively)
+			if err != nil {
+				return nil, fmt.Errorf("parsing data plane scope: %+v", err)
+			}
+
+			parseResult.Parsed[p.segments[1].Name] = *scope
+			uri = strings.ReplaceAll(uri, *scope, "/fakeScope")
+		}
 	}
 
 	// trim off the scopePrefix and the leading `/` to give us the segments we expect plus the final scope string
 	// at the end, if present
-	uri := input
+
 	if hasScopeAtStart || hasDataPlaneBaseURIAtStart {
 		uri = strings.TrimPrefix(uri, idPrefix)
 		uri = strings.TrimPrefix(uri, "/")
@@ -180,8 +192,15 @@ func (p Parser) Parse(input string, insensitively bool) (*ParseResult, error) {
 		uri = strings.TrimPrefix(uri, "fakestart/")
 	}
 
+	if dataPlaneHasScopeAtStart {
+		uri = strings.TrimPrefix(uri, "fakeScope")
+		if strings.HasPrefix(uri, "/") {
+			uri = strings.TrimPrefix(uri, "/")
+		}
+	}
+
 	for i, segment := range p.segments {
-		if (i == 0 && hasScopeAtStart) || (i == 0 && hasDataPlaneBaseURIAtStart) || (i == len(p.segments)-1 && hasScopeAtEnd) {
+		if (i == 0 && hasScopeAtStart) || (i == 0 && hasDataPlaneBaseURIAtStart) || (i == len(p.segments)-1 && hasScopeAtEnd) || (i == 1 && dataPlaneHasScopeAtStart) {
 			continue
 		}
 
@@ -248,6 +267,38 @@ func (p Parser) parseScopePrefix(input, regexForNonScopeSegments string, insensi
 		return nil, fmt.Errorf("unable to find the scope prefix from the value %q using the regex %q", input, regexToUse)
 	}
 	return &v, nil
+}
+
+func (p Parser) parseScopeSegment(input, regexForNonScopeSegments string, insensitively bool) (*string, error) {
+	knownPatterns := []string{
+		`(subscriptions\/[^\/]+\/resourceGroups\/[^\/]+)`,
+		// `(subscriptions\/[^\/]+\/resourceGroups\/[^\/]+)\/`,
+		`providers/Microsoft.Management/managementGroups/[^\/]+`,
+	}
+	for _, regexToUse := range knownPatterns {
+		// TODO - if the ID contains more than 1 `providers` then the first is part of the scope so we need to consume it here *sigh*
+		if insensitively {
+			regexToUse = fmt.Sprintf("(?i)%s", regexToUse)
+		}
+		r, err := regexp.Compile(regexToUse)
+		if err != nil {
+			return nil, fmt.Errorf("internal error: compiling regex %q to find scope prefix: %+v", regexToUse, err)
+		}
+		// 0 is the entire string, 1 will be the scope prefix, we can ignore the rest
+		values := r.FindStringSubmatch(input)
+		if len(values) < 2 {
+			return nil, fmt.Errorf("unable to find the scope prefix from the value %q with the regex %q", input, regexToUse)
+		}
+		v := values[1]
+		if v == "" {
+			return nil, fmt.Errorf("unable to find the scope prefix from the value %q using the regex %q", input, regexToUse)
+		}
+		if !strings.HasPrefix(v, "/") {
+			v = "/" + v
+		}
+		return &v, nil
+	}
+	return nil, fmt.Errorf("input %q does not match any supported scope pattern", input)
 }
 
 func (p Parser) parseDataPlaneBaseURIPrefix(input string) (*string, error) {

--- a/resourcemanager/resourceids/parse.go
+++ b/resourcemanager/resourceids/parse.go
@@ -94,7 +94,10 @@ func (p Parser) Parse(input string, insensitively bool) (*ParseResult, error) {
 	hasScopeAtStart := p.segments[0].Type == ScopeSegmentType
 	hasScopeAtEnd := p.segments[len(p.segments)-1].Type == ScopeSegmentType
 	hasDataPlaneBaseURIAtStart := p.segments[0].Type == DataPlaneBaseURISegmentType
-	dataPlaneHasScopeAtStart := p.segments[1].Type == ScopeSegmentType && hasDataPlaneBaseURIAtStart
+	dataPlaneHasScopeAtStart := false
+	if len(p.segments) > 1 {
+		dataPlaneHasScopeAtStart = p.segments[1].Type == ScopeSegmentType && hasDataPlaneBaseURIAtStart
+	}
 
 	// go through and build up a regex which will count for the `middle` components of the Resource ID
 	nonScopeComponentsRegex := ""


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Adds support for Azure Data Plane IDs that have a scope prefix

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* resource IDs - support Data Plane IDs with Scope at beginning (after baseURI).


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
