### PR TITLE
Identity: implement the (Un)Marshaler on value type instead of pointer type

### DIFF
--- a/resourcemanager/identity/legacy_system_and_user_assigned_list.go
+++ b/resourcemanager/identity/legacy_system_and_user_assigned_list.go
@@ -20,30 +20,28 @@ type LegacySystemAndUserAssignedList struct {
 	IdentityIds []string `json:"userAssignedIdentities" tfschema:"identity_ids"`
 }
 
-func (s *LegacySystemAndUserAssignedList) MarshalJSON() ([]byte, error) {
+func (s LegacySystemAndUserAssignedList) MarshalJSON() ([]byte, error) {
 	// we use a custom marshal function here since we can only send the Type / UserAssignedIdentities field
 	identityType := TypeNone
 	userAssignedIdentityIds := []string{}
 
-	if s != nil {
-		if s.Type == typeLegacySystemAssignedUserAssigned {
-			return nil, fmt.Errorf("internal error: the legacy `SystemAssigned,UserAssigned` identity type should be being converted to the schema type - this is a bug")
-		}
+	if s.Type == typeLegacySystemAssignedUserAssigned {
+		return nil, fmt.Errorf("internal error: the legacy `SystemAssigned,UserAssigned` identity type should be being converted to the schema type - this is a bug")
+	}
 
-		if s.Type == TypeSystemAssigned {
-			identityType = TypeSystemAssigned
-		}
-		if s.Type == TypeSystemAssignedUserAssigned {
-			// convert the Schema value (w/spaces) to the legacy API value (w/o spaces)
-			identityType = typeLegacySystemAssignedUserAssigned
-		}
-		if s.Type == TypeUserAssigned {
-			identityType = TypeUserAssigned
-		}
+	if s.Type == TypeSystemAssigned {
+		identityType = TypeSystemAssigned
+	}
+	if s.Type == TypeSystemAssignedUserAssigned {
+		// convert the Schema value (w/spaces) to the legacy API value (w/o spaces)
+		identityType = typeLegacySystemAssignedUserAssigned
+	}
+	if s.Type == TypeUserAssigned {
+		identityType = TypeUserAssigned
+	}
 
-		if identityType != TypeNone {
-			userAssignedIdentityIds = s.IdentityIds
-		}
+	if identityType != TypeNone {
+		userAssignedIdentityIds = s.IdentityIds
 	}
 
 	out := map[string]interface{}{

--- a/resourcemanager/identity/legacy_system_and_user_assigned_list_test.go
+++ b/resourcemanager/identity/legacy_system_and_user_assigned_list_test.go
@@ -12,24 +12,28 @@ import (
 
 func TestLegacySystemUserAssignedListMarshal(t *testing.T) {
 	testData := []struct {
-		input                           *LegacySystemAndUserAssignedList
+		input                           any
+		expect                          map[string]any
 		expectedIdentityType            string
 		expectedUserAssignedIdentityIds []string
 		expectError                     bool
 	}{
 		{
-			input:                           nil,
-			expectedIdentityType:            "None",
-			expectedUserAssignedIdentityIds: []string{},
-		},
-		{
-			input:                           &LegacySystemAndUserAssignedList{},
+			input: &LegacySystemAndUserAssignedList{},
+			expect: map[string]any{
+				"type":                   "None",
+				"userAssignedIdentities": nil,
+			},
 			expectedIdentityType:            "None",
 			expectedUserAssignedIdentityIds: []string{},
 		},
 		{
 			input: &LegacySystemAndUserAssignedList{
 				Type: TypeNone,
+			},
+			expect: map[string]any{
+				"type":                   "None",
+				"userAssignedIdentities": nil,
 			},
 			expectedIdentityType:            "None",
 			expectedUserAssignedIdentityIds: []string{},
@@ -41,6 +45,10 @@ func TestLegacySystemUserAssignedListMarshal(t *testing.T) {
 					"first",
 				},
 			},
+			expect: map[string]any{
+				"type":                   "None",
+				"userAssignedIdentities": nil,
+			},
 			expectedIdentityType:            "None",
 			expectedUserAssignedIdentityIds: []string{
 				// intentionally empty since this is bad data
@@ -51,6 +59,23 @@ func TestLegacySystemUserAssignedListMarshal(t *testing.T) {
 				Type:        TypeSystemAssigned,
 				IdentityIds: []string{},
 			},
+			expect: map[string]any{
+				"type":                   "SystemAssigned",
+				"userAssignedIdentities": nil,
+			},
+			expectedIdentityType:            "SystemAssigned",
+			expectedUserAssignedIdentityIds: []string{},
+		},
+		{
+			// Value type (instead of pointer type)
+			input: LegacySystemAndUserAssignedList{
+				Type:        TypeSystemAssigned,
+				IdentityIds: []string{},
+			},
+			expect: map[string]any{
+				"type":                   "SystemAssigned",
+				"userAssignedIdentities": nil,
+			},
 			expectedIdentityType:            "SystemAssigned",
 			expectedUserAssignedIdentityIds: []string{},
 		},
@@ -58,6 +83,10 @@ func TestLegacySystemUserAssignedListMarshal(t *testing.T) {
 			input: &LegacySystemAndUserAssignedList{
 				Type:        TypeSystemAssignedUserAssigned,
 				IdentityIds: []string{},
+			},
+			expect: map[string]any{
+				"type":                   "SystemAssigned,UserAssigned",
+				"userAssignedIdentities": nil,
 			},
 			expectedIdentityType:            "SystemAssigned,UserAssigned",
 			expectedUserAssignedIdentityIds: []string{},
@@ -74,6 +103,10 @@ func TestLegacySystemUserAssignedListMarshal(t *testing.T) {
 				Type:        TypeUserAssigned,
 				IdentityIds: []string{},
 			},
+			expect: map[string]any{
+				"type":                   "UserAssigned",
+				"userAssignedIdentities": nil,
+			},
 			expectedIdentityType:            "UserAssigned",
 			expectedUserAssignedIdentityIds: []string{},
 		},
@@ -81,6 +114,13 @@ func TestLegacySystemUserAssignedListMarshal(t *testing.T) {
 			input: &LegacySystemAndUserAssignedList{
 				Type: TypeSystemAssignedUserAssigned,
 				IdentityIds: []string{
+					"first",
+					"second",
+				},
+			},
+			expect: map[string]any{
+				"type": "SystemAssigned,UserAssigned",
+				"userAssignedIdentities": []any{
 					"first",
 					"second",
 				},
@@ -109,6 +149,13 @@ func TestLegacySystemUserAssignedListMarshal(t *testing.T) {
 					"second",
 				},
 			},
+			expect: map[string]any{
+				"type": "UserAssigned",
+				"userAssignedIdentities": []any{
+					"first",
+					"second",
+				},
+			},
 			expectedIdentityType: "UserAssigned",
 			expectedUserAssignedIdentityIds: []string{
 				"first",
@@ -119,7 +166,7 @@ func TestLegacySystemUserAssignedListMarshal(t *testing.T) {
 	for i, v := range testData {
 		t.Logf("step %d..", i)
 
-		encoded, err := v.input.MarshalJSON()
+		encoded, err := json.Marshal(v.input)
 		if err != nil {
 			if v.expectError {
 				continue
@@ -129,6 +176,11 @@ func TestLegacySystemUserAssignedListMarshal(t *testing.T) {
 		}
 		if v.expectError {
 			t.Fatalf("expected an error but didn't get one")
+		}
+
+		expectEncoded, _ := json.Marshal(v.expect)
+		if string(encoded) != string(expectEncoded) {
+			t.Fatalf("marshaled JSON is not as expected. got=%v, expect=%v", string(encoded), string(expectEncoded))
 		}
 
 		var out map[string]interface{}

--- a/resourcemanager/identity/legacy_system_and_user_assigned_list_test.go
+++ b/resourcemanager/identity/legacy_system_and_user_assigned_list_test.go
@@ -178,9 +178,19 @@ func TestLegacySystemUserAssignedListMarshal(t *testing.T) {
 			t.Fatalf("expected an error but didn't get one")
 		}
 
+		encodedDirect, err := v.input.(json.Marshaler).MarshalJSON()
+		if err != nil {
+			t.Fatalf("direct marshaling: %+v", err)
+		}
+
 		expectEncoded, _ := json.Marshal(v.expect)
+
 		if string(encoded) != string(expectEncoded) {
 			t.Fatalf("marshaled JSON is not as expected. got=%v, expect=%v", string(encoded), string(expectEncoded))
+		}
+
+		if string(encodedDirect) != string(expectEncoded) {
+			t.Fatalf("direct marshaled JSON is not as expected. got=%v, expect=%v", string(encodedDirect), string(expectEncoded))
 		}
 
 		var out map[string]interface{}

--- a/resourcemanager/identity/legacy_system_and_user_assigned_map.go
+++ b/resourcemanager/identity/legacy_system_and_user_assigned_map.go
@@ -21,30 +21,28 @@ type LegacySystemAndUserAssignedMap struct {
 	IdentityIds map[string]UserAssignedIdentityDetails `json:"userAssignedIdentities"`
 }
 
-func (s *LegacySystemAndUserAssignedMap) MarshalJSON() ([]byte, error) {
+func (s LegacySystemAndUserAssignedMap) MarshalJSON() ([]byte, error) {
 	// we use a custom marshal function here since we can only send the Type / UserAssignedIdentities field
 	identityType := TypeNone
 	userAssignedIdentityIds := map[string]UserAssignedIdentityDetails{}
 
-	if s != nil {
-		if s.Type == typeLegacySystemAssignedUserAssigned {
-			return nil, fmt.Errorf("internal error: the legacy `SystemAssigned,UserAssigned` identity type should be being converted to the schema type - this is a bug")
-		}
+	if s.Type == typeLegacySystemAssignedUserAssigned {
+		return nil, fmt.Errorf("internal error: the legacy `SystemAssigned,UserAssigned` identity type should be being converted to the schema type - this is a bug")
+	}
 
-		if s.Type == TypeSystemAssigned {
-			identityType = TypeSystemAssigned
-		}
-		if s.Type == TypeSystemAssignedUserAssigned {
-			// convert the Schema value (w/spaces) to the legacy API value (w/o spaces)
-			identityType = typeLegacySystemAssignedUserAssigned
-		}
-		if s.Type == TypeUserAssigned {
-			identityType = TypeUserAssigned
-		}
+	if s.Type == TypeSystemAssigned {
+		identityType = TypeSystemAssigned
+	}
+	if s.Type == TypeSystemAssignedUserAssigned {
+		// convert the Schema value (w/spaces) to the legacy API value (w/o spaces)
+		identityType = typeLegacySystemAssignedUserAssigned
+	}
+	if s.Type == TypeUserAssigned {
+		identityType = TypeUserAssigned
+	}
 
-		if identityType != TypeNone {
-			userAssignedIdentityIds = s.IdentityIds
-		}
+	if identityType != TypeNone {
+		userAssignedIdentityIds = s.IdentityIds
 	}
 
 	out := map[string]interface{}{

--- a/resourcemanager/identity/legacy_system_and_user_assigned_map_test.go
+++ b/resourcemanager/identity/legacy_system_and_user_assigned_map_test.go
@@ -179,9 +179,19 @@ func TestLegacySystemUserAssignedMapMarshal(t *testing.T) {
 			t.Fatalf("expected an error but didn't get one")
 		}
 
+		encodedDirect, err := v.input.(json.Marshaler).MarshalJSON()
+		if err != nil {
+			t.Fatalf("direct marshaling: %+v", err)
+		}
+
 		expectEncoded, _ := json.Marshal(v.expect)
+
 		if string(encoded) != string(expectEncoded) {
 			t.Fatalf("marshaled JSON is not as expected. got=%v, expect=%v", string(encoded), string(expectEncoded))
+		}
+
+		if string(encodedDirect) != string(expectEncoded) {
+			t.Fatalf("direct marshaled JSON is not as expected. got=%v, expect=%v", string(encodedDirect), string(expectEncoded))
 		}
 
 		var out map[string]interface{}

--- a/resourcemanager/identity/legacy_system_and_user_assigned_map_test.go
+++ b/resourcemanager/identity/legacy_system_and_user_assigned_map_test.go
@@ -13,24 +13,28 @@ import (
 
 func TestLegacySystemUserAssignedMapMarshal(t *testing.T) {
 	testData := []struct {
-		input                           *LegacySystemAndUserAssignedMap
+		input                           any
+		expect                          map[string]any
 		expectedIdentityType            string
 		expectedUserAssignedIdentityIds []string
 		expectError                     bool
 	}{
 		{
-			input:                           nil,
-			expectedIdentityType:            "None",
-			expectedUserAssignedIdentityIds: []string{},
-		},
-		{
-			input:                           &LegacySystemAndUserAssignedMap{},
+			input: &LegacySystemAndUserAssignedMap{},
+			expect: map[string]any{
+				"type":                   "None",
+				"userAssignedIdentities": nil,
+			},
 			expectedIdentityType:            "None",
 			expectedUserAssignedIdentityIds: []string{},
 		},
 		{
 			input: &LegacySystemAndUserAssignedMap{
 				Type: TypeNone,
+			},
+			expect: map[string]any{
+				"type":                   "None",
+				"userAssignedIdentities": nil,
 			},
 			expectedIdentityType:            "None",
 			expectedUserAssignedIdentityIds: []string{},
@@ -42,6 +46,10 @@ func TestLegacySystemUserAssignedMapMarshal(t *testing.T) {
 					"first": {},
 				},
 			},
+			expect: map[string]any{
+				"type":                   "None",
+				"userAssignedIdentities": nil,
+			},
 			expectedIdentityType:            "None",
 			expectedUserAssignedIdentityIds: []string{
 				// intentionally empty since this is bad data
@@ -52,6 +60,23 @@ func TestLegacySystemUserAssignedMapMarshal(t *testing.T) {
 				Type:        TypeSystemAssigned,
 				IdentityIds: map[string]UserAssignedIdentityDetails{},
 			},
+			expect: map[string]any{
+				"type":                   "SystemAssigned",
+				"userAssignedIdentities": nil,
+			},
+			expectedIdentityType:            "SystemAssigned",
+			expectedUserAssignedIdentityIds: []string{},
+		},
+		{
+			// Value type (instead of pointer type)
+			input: LegacySystemAndUserAssignedMap{
+				Type:        TypeSystemAssigned,
+				IdentityIds: map[string]UserAssignedIdentityDetails{},
+			},
+			expect: map[string]any{
+				"type":                   "SystemAssigned",
+				"userAssignedIdentities": nil,
+			},
 			expectedIdentityType:            "SystemAssigned",
 			expectedUserAssignedIdentityIds: []string{},
 		},
@@ -59,6 +84,10 @@ func TestLegacySystemUserAssignedMapMarshal(t *testing.T) {
 			input: &LegacySystemAndUserAssignedMap{
 				Type:        TypeSystemAssignedUserAssigned,
 				IdentityIds: map[string]UserAssignedIdentityDetails{},
+			},
+			expect: map[string]any{
+				"type":                   "SystemAssigned,UserAssigned",
+				"userAssignedIdentities": nil,
 			},
 			expectedIdentityType:            "SystemAssigned,UserAssigned",
 			expectedUserAssignedIdentityIds: []string{},
@@ -75,6 +104,10 @@ func TestLegacySystemUserAssignedMapMarshal(t *testing.T) {
 				Type:        TypeUserAssigned,
 				IdentityIds: map[string]UserAssignedIdentityDetails{},
 			},
+			expect: map[string]any{
+				"type":                   "UserAssigned",
+				"userAssignedIdentities": nil,
+			},
 			expectedIdentityType:            "UserAssigned",
 			expectedUserAssignedIdentityIds: []string{},
 		},
@@ -84,6 +117,13 @@ func TestLegacySystemUserAssignedMapMarshal(t *testing.T) {
 				IdentityIds: map[string]UserAssignedIdentityDetails{
 					"first":  {},
 					"second": {},
+				},
+			},
+			expect: map[string]any{
+				"type": "SystemAssigned,UserAssigned",
+				"userAssignedIdentities": map[string]any{
+					"first":  map[string]any{},
+					"second": map[string]any{},
 				},
 			},
 			expectedIdentityType: "SystemAssigned,UserAssigned",
@@ -110,6 +150,13 @@ func TestLegacySystemUserAssignedMapMarshal(t *testing.T) {
 					"second": {},
 				},
 			},
+			expect: map[string]any{
+				"type": "UserAssigned",
+				"userAssignedIdentities": map[string]any{
+					"first":  map[string]any{},
+					"second": map[string]any{},
+				},
+			},
 			expectedIdentityType: "UserAssigned",
 			expectedUserAssignedIdentityIds: []string{
 				"first",
@@ -120,7 +167,7 @@ func TestLegacySystemUserAssignedMapMarshal(t *testing.T) {
 	for i, v := range testData {
 		t.Logf("step %d..", i)
 
-		encoded, err := v.input.MarshalJSON()
+		encoded, err := json.Marshal(v.input)
 		if err != nil {
 			if v.expectError {
 				continue
@@ -130,6 +177,11 @@ func TestLegacySystemUserAssignedMapMarshal(t *testing.T) {
 		}
 		if v.expectError {
 			t.Fatalf("expected an error but didn't get one")
+		}
+
+		expectEncoded, _ := json.Marshal(v.expect)
+		if string(encoded) != string(expectEncoded) {
+			t.Fatalf("marshaled JSON is not as expected. got=%v, expect=%v", string(encoded), string(expectEncoded))
 		}
 
 		var out map[string]interface{}

--- a/resourcemanager/identity/system_and_user_assigned_list.go
+++ b/resourcemanager/identity/system_and_user_assigned_list.go
@@ -20,25 +20,23 @@ type SystemAndUserAssignedList struct {
 	IdentityIds []string `json:"userAssignedIdentities" tfschema:"identity_ids"`
 }
 
-func (s *SystemAndUserAssignedList) MarshalJSON() ([]byte, error) {
+func (s SystemAndUserAssignedList) MarshalJSON() ([]byte, error) {
 	// we use a custom marshal function here since we can only send the Type / UserAssignedIdentities field
 	identityType := TypeNone
 	userAssignedIdentityIds := []string{}
 
-	if s != nil {
-		if s.Type == TypeSystemAssigned {
-			identityType = TypeSystemAssigned
-		}
-		if s.Type == TypeSystemAssignedUserAssigned {
-			identityType = TypeSystemAssignedUserAssigned
-		}
-		if s.Type == TypeUserAssigned {
-			identityType = TypeUserAssigned
-		}
+	if s.Type == TypeSystemAssigned {
+		identityType = TypeSystemAssigned
+	}
+	if s.Type == TypeSystemAssignedUserAssigned {
+		identityType = TypeSystemAssignedUserAssigned
+	}
+	if s.Type == TypeUserAssigned {
+		identityType = TypeUserAssigned
+	}
 
-		if identityType != TypeNone {
-			userAssignedIdentityIds = s.IdentityIds
-		}
+	if identityType != TypeNone {
+		userAssignedIdentityIds = s.IdentityIds
 	}
 
 	out := map[string]interface{}{

--- a/resourcemanager/identity/system_and_user_assigned_list_test.go
+++ b/resourcemanager/identity/system_and_user_assigned_list_test.go
@@ -12,23 +12,27 @@ import (
 
 func TestSystemUserAssignedListMarshal(t *testing.T) {
 	testData := []struct {
-		input                           *SystemAndUserAssignedList
+		input                           any
+		expect                          map[string]any
 		expectedIdentityType            string
 		expectedUserAssignedIdentityIds []string
 	}{
 		{
-			input:                           nil,
-			expectedIdentityType:            "None",
-			expectedUserAssignedIdentityIds: []string{},
-		},
-		{
-			input:                           &SystemAndUserAssignedList{},
+			input: &SystemAndUserAssignedList{},
+			expect: map[string]any{
+				"type":                   "None",
+				"userAssignedIdentities": nil,
+			},
 			expectedIdentityType:            "None",
 			expectedUserAssignedIdentityIds: []string{},
 		},
 		{
 			input: &SystemAndUserAssignedList{
 				Type: TypeNone,
+			},
+			expect: map[string]any{
+				"type":                   "None",
+				"userAssignedIdentities": nil,
 			},
 			expectedIdentityType:            "None",
 			expectedUserAssignedIdentityIds: []string{},
@@ -40,6 +44,10 @@ func TestSystemUserAssignedListMarshal(t *testing.T) {
 					"first",
 				},
 			},
+			expect: map[string]any{
+				"type":                   "None",
+				"userAssignedIdentities": nil,
+			},
 			expectedIdentityType:            "None",
 			expectedUserAssignedIdentityIds: []string{
 				// intentionally empty since this is bad data
@@ -50,6 +58,23 @@ func TestSystemUserAssignedListMarshal(t *testing.T) {
 				Type:        TypeSystemAssigned,
 				IdentityIds: []string{},
 			},
+			expect: map[string]any{
+				"type":                   "SystemAssigned",
+				"userAssignedIdentities": nil,
+			},
+			expectedIdentityType:            "SystemAssigned",
+			expectedUserAssignedIdentityIds: []string{},
+		},
+		{
+			// Value type (instead of pointer type)
+			input: SystemAndUserAssignedList{
+				Type:        TypeSystemAssigned,
+				IdentityIds: []string{},
+			},
+			expect: map[string]any{
+				"type":                   "SystemAssigned",
+				"userAssignedIdentities": nil,
+			},
 			expectedIdentityType:            "SystemAssigned",
 			expectedUserAssignedIdentityIds: []string{},
 		},
@@ -57,6 +82,10 @@ func TestSystemUserAssignedListMarshal(t *testing.T) {
 			input: &SystemAndUserAssignedList{
 				Type:        TypeSystemAssignedUserAssigned,
 				IdentityIds: []string{},
+			},
+			expect: map[string]any{
+				"type":                   "SystemAssigned, UserAssigned",
+				"userAssignedIdentities": nil,
 			},
 			expectedIdentityType:            "SystemAssigned, UserAssigned",
 			expectedUserAssignedIdentityIds: []string{},
@@ -66,6 +95,10 @@ func TestSystemUserAssignedListMarshal(t *testing.T) {
 				Type:        TypeUserAssigned,
 				IdentityIds: []string{},
 			},
+			expect: map[string]any{
+				"type":                   "UserAssigned",
+				"userAssignedIdentities": nil,
+			},
 			expectedIdentityType:            "UserAssigned",
 			expectedUserAssignedIdentityIds: []string{},
 		},
@@ -74,6 +107,13 @@ func TestSystemUserAssignedListMarshal(t *testing.T) {
 			input: &SystemAndUserAssignedList{
 				Type: TypeSystemAssignedUserAssigned,
 				IdentityIds: []string{
+					"first",
+					"second",
+				},
+			},
+			expect: map[string]any{
+				"type": "SystemAssigned, UserAssigned",
+				"userAssignedIdentities": []any{
 					"first",
 					"second",
 				},
@@ -92,6 +132,13 @@ func TestSystemUserAssignedListMarshal(t *testing.T) {
 					"second",
 				},
 			},
+			expect: map[string]any{
+				"type": "UserAssigned",
+				"userAssignedIdentities": []any{
+					"first",
+					"second",
+				},
+			},
 			expectedIdentityType: "UserAssigned",
 			expectedUserAssignedIdentityIds: []string{
 				"first",
@@ -102,9 +149,14 @@ func TestSystemUserAssignedListMarshal(t *testing.T) {
 	for i, v := range testData {
 		t.Logf("step %d..", i)
 
-		encoded, err := v.input.MarshalJSON()
+		encoded, err := json.Marshal(v.input)
 		if err != nil {
 			t.Fatalf("marshaling: %+v", err)
+		}
+
+		expectEncoded, _ := json.Marshal(v.expect)
+		if string(encoded) != string(expectEncoded) {
+			t.Fatalf("marshaled JSON is not as expected. got=%v, expect=%v", string(encoded), string(expectEncoded))
 		}
 
 		var out map[string]interface{}

--- a/resourcemanager/identity/system_and_user_assigned_list_test.go
+++ b/resourcemanager/identity/system_and_user_assigned_list_test.go
@@ -154,9 +154,19 @@ func TestSystemUserAssignedListMarshal(t *testing.T) {
 			t.Fatalf("marshaling: %+v", err)
 		}
 
+		encodedDirect, err := v.input.(json.Marshaler).MarshalJSON()
+		if err != nil {
+			t.Fatalf("direct marshaling: %+v", err)
+		}
+
 		expectEncoded, _ := json.Marshal(v.expect)
+
 		if string(encoded) != string(expectEncoded) {
 			t.Fatalf("marshaled JSON is not as expected. got=%v, expect=%v", string(encoded), string(expectEncoded))
+		}
+
+		if string(encodedDirect) != string(expectEncoded) {
+			t.Fatalf("direct marshaled JSON is not as expected. got=%v, expect=%v", string(encodedDirect), string(expectEncoded))
 		}
 
 		var out map[string]interface{}

--- a/resourcemanager/identity/system_and_user_assigned_map.go
+++ b/resourcemanager/identity/system_and_user_assigned_map.go
@@ -20,25 +20,23 @@ type SystemAndUserAssignedMap struct {
 	IdentityIds map[string]UserAssignedIdentityDetails `json:"userAssignedIdentities"`
 }
 
-func (s *SystemAndUserAssignedMap) MarshalJSON() ([]byte, error) {
+func (s SystemAndUserAssignedMap) MarshalJSON() ([]byte, error) {
 	// we use a custom marshal function here since we can only send the Type / UserAssignedIdentities field
 	identityType := TypeNone
 	userAssignedIdentityIds := map[string]UserAssignedIdentityDetails{}
 
-	if s != nil {
-		if s.Type == TypeSystemAssigned {
-			identityType = TypeSystemAssigned
-		}
-		if s.Type == TypeSystemAssignedUserAssigned {
-			identityType = TypeSystemAssignedUserAssigned
-		}
-		if s.Type == TypeUserAssigned {
-			identityType = TypeUserAssigned
-		}
+	if s.Type == TypeSystemAssigned {
+		identityType = TypeSystemAssigned
+	}
+	if s.Type == TypeSystemAssignedUserAssigned {
+		identityType = TypeSystemAssignedUserAssigned
+	}
+	if s.Type == TypeUserAssigned {
+		identityType = TypeUserAssigned
+	}
 
-		if identityType != TypeNone {
-			userAssignedIdentityIds = s.IdentityIds
-		}
+	if identityType != TypeNone {
+		userAssignedIdentityIds = s.IdentityIds
 	}
 
 	out := map[string]interface{}{

--- a/resourcemanager/identity/system_and_user_assigned_map_test.go
+++ b/resourcemanager/identity/system_and_user_assigned_map_test.go
@@ -13,23 +13,27 @@ import (
 
 func TestSystemUserAssignedMapMarshal(t *testing.T) {
 	testData := []struct {
-		input                           *SystemAndUserAssignedMap
+		input                           any
+		expect                          map[string]any
 		expectedIdentityType            string
 		expectedUserAssignedIdentityIds []string
 	}{
 		{
-			input:                           nil,
-			expectedIdentityType:            "None",
-			expectedUserAssignedIdentityIds: []string{},
-		},
-		{
-			input:                           &SystemAndUserAssignedMap{},
+			input: &SystemAndUserAssignedMap{},
+			expect: map[string]any{
+				"type":                   "None",
+				"userAssignedIdentities": nil,
+			},
 			expectedIdentityType:            "None",
 			expectedUserAssignedIdentityIds: []string{},
 		},
 		{
 			input: &SystemAndUserAssignedMap{
 				Type: TypeNone,
+			},
+			expect: map[string]any{
+				"type":                   "None",
+				"userAssignedIdentities": nil,
 			},
 			expectedIdentityType:            "None",
 			expectedUserAssignedIdentityIds: []string{},
@@ -41,6 +45,10 @@ func TestSystemUserAssignedMapMarshal(t *testing.T) {
 					"first": {},
 				},
 			},
+			expect: map[string]any{
+				"type":                   "None",
+				"userAssignedIdentities": nil,
+			},
 			expectedIdentityType:            "None",
 			expectedUserAssignedIdentityIds: []string{
 				// intentionally empty since this is bad data
@@ -51,6 +59,23 @@ func TestSystemUserAssignedMapMarshal(t *testing.T) {
 				Type:        TypeSystemAssigned,
 				IdentityIds: map[string]UserAssignedIdentityDetails{},
 			},
+			expect: map[string]any{
+				"type":                   "SystemAssigned",
+				"userAssignedIdentities": nil,
+			},
+			expectedIdentityType:            "SystemAssigned",
+			expectedUserAssignedIdentityIds: []string{},
+		},
+		{
+			// Value type (instead of pointer type)
+			input: SystemAndUserAssignedMap{
+				Type:        TypeSystemAssigned,
+				IdentityIds: map[string]UserAssignedIdentityDetails{},
+			},
+			expect: map[string]any{
+				"type":                   "SystemAssigned",
+				"userAssignedIdentities": nil,
+			},
 			expectedIdentityType:            "SystemAssigned",
 			expectedUserAssignedIdentityIds: []string{},
 		},
@@ -59,6 +84,10 @@ func TestSystemUserAssignedMapMarshal(t *testing.T) {
 				Type:        TypeSystemAssignedUserAssigned,
 				IdentityIds: map[string]UserAssignedIdentityDetails{},
 			},
+			expect: map[string]any{
+				"type":                   "SystemAssigned, UserAssigned",
+				"userAssignedIdentities": nil,
+			},
 			expectedIdentityType:            "SystemAssigned, UserAssigned",
 			expectedUserAssignedIdentityIds: []string{},
 		},
@@ -66,6 +95,10 @@ func TestSystemUserAssignedMapMarshal(t *testing.T) {
 			input: &SystemAndUserAssignedMap{
 				Type:        TypeUserAssigned,
 				IdentityIds: map[string]UserAssignedIdentityDetails{},
+			},
+			expect: map[string]any{
+				"type":                   "UserAssigned",
+				"userAssignedIdentities": nil,
 			},
 			expectedIdentityType:            "UserAssigned",
 			expectedUserAssignedIdentityIds: []string{},
@@ -77,6 +110,13 @@ func TestSystemUserAssignedMapMarshal(t *testing.T) {
 				IdentityIds: map[string]UserAssignedIdentityDetails{
 					"first":  {},
 					"second": {},
+				},
+			},
+			expect: map[string]any{
+				"type": "SystemAssigned, UserAssigned",
+				"userAssignedIdentities": map[string]any{
+					"first":  map[string]any{},
+					"second": map[string]any{},
 				},
 			},
 			expectedIdentityType: "SystemAssigned, UserAssigned",
@@ -93,6 +133,13 @@ func TestSystemUserAssignedMapMarshal(t *testing.T) {
 					"second": {},
 				},
 			},
+			expect: map[string]any{
+				"type": "UserAssigned",
+				"userAssignedIdentities": map[string]any{
+					"first":  map[string]any{},
+					"second": map[string]any{},
+				},
+			},
 			expectedIdentityType: "UserAssigned",
 			expectedUserAssignedIdentityIds: []string{
 				"first",
@@ -103,9 +150,14 @@ func TestSystemUserAssignedMapMarshal(t *testing.T) {
 	for i, v := range testData {
 		t.Logf("step %d..", i)
 
-		encoded, err := v.input.MarshalJSON()
+		encoded, err := json.Marshal(v.input)
 		if err != nil {
 			t.Fatalf("marshaling: %+v", err)
+		}
+
+		expectEncoded, _ := json.Marshal(v.expect)
+		if string(encoded) != string(expectEncoded) {
+			t.Fatalf("marshaled JSON is not as expected. got=%v, expect=%v", string(encoded), string(expectEncoded))
 		}
 
 		var out map[string]interface{}

--- a/resourcemanager/identity/system_and_user_assigned_map_test.go
+++ b/resourcemanager/identity/system_and_user_assigned_map_test.go
@@ -155,9 +155,19 @@ func TestSystemUserAssignedMapMarshal(t *testing.T) {
 			t.Fatalf("marshaling: %+v", err)
 		}
 
+		encodedDirect, err := v.input.(json.Marshaler).MarshalJSON()
+		if err != nil {
+			t.Fatalf("direct marshaling: %+v", err)
+		}
+
 		expectEncoded, _ := json.Marshal(v.expect)
+
 		if string(encoded) != string(expectEncoded) {
 			t.Fatalf("marshaled JSON is not as expected. got=%v, expect=%v", string(encoded), string(expectEncoded))
+		}
+
+		if string(encodedDirect) != string(expectEncoded) {
+			t.Fatalf("direct marshaled JSON is not as expected. got=%v, expect=%v", string(encodedDirect), string(expectEncoded))
 		}
 
 		var out map[string]interface{}

--- a/resourcemanager/identity/system_assigned.go
+++ b/resourcemanager/identity/system_assigned.go
@@ -15,12 +15,12 @@ type SystemAssigned struct {
 	TenantId    string `json:"tenantId" tfschema:"tenant_id"`
 }
 
-func (s *SystemAssigned) MarshalJSON() ([]byte, error) {
+func (s SystemAssigned) MarshalJSON() ([]byte, error) {
 	// we use a custom marshal function here since we can only send the Type field
 	out := map[string]interface{}{
 		"type": string(TypeNone),
 	}
-	if s != nil && s.Type == TypeSystemAssigned {
+	if s.Type == TypeSystemAssigned {
 		out["type"] = string(TypeSystemAssigned)
 	}
 	return json.Marshal(out)

--- a/resourcemanager/identity/system_assigned_test.go
+++ b/resourcemanager/identity/system_assigned_test.go
@@ -10,20 +10,23 @@ import (
 
 func TestSystemAssignedMarshal(t *testing.T) {
 	testData := []struct {
-		input         *SystemAssigned
+		input         any
+		expect        map[string]any
 		expectedValue string
 	}{
 		{
-			input:         nil,
-			expectedValue: "None",
-		},
-		{
-			input:         &SystemAssigned{},
+			input: &SystemAssigned{},
+			expect: map[string]any{
+				"type": "None",
+			},
 			expectedValue: "None",
 		},
 		{
 			input: &SystemAssigned{
 				Type: TypeNone,
+			},
+			expect: map[string]any{
+				"type": "None",
 			},
 			expectedValue: "None",
 		},
@@ -31,11 +34,17 @@ func TestSystemAssignedMarshal(t *testing.T) {
 			input: &SystemAssigned{
 				Type: TypeSystemAssignedUserAssigned,
 			},
+			expect: map[string]any{
+				"type": "None",
+			},
 			expectedValue: "None",
 		},
 		{
 			input: &SystemAssigned{
 				Type: TypeUserAssigned,
+			},
+			expect: map[string]any{
+				"type": "None",
 			},
 			expectedValue: "None",
 		},
@@ -43,15 +52,33 @@ func TestSystemAssignedMarshal(t *testing.T) {
 			input: &SystemAssigned{
 				Type: TypeSystemAssigned,
 			},
+			expect: map[string]any{
+				"type": "SystemAssigned",
+			},
+			expectedValue: "SystemAssigned",
+		},
+		{
+			// Value type (instead of pointer type)
+			input: SystemAssigned{
+				Type: TypeSystemAssigned,
+			},
+			expect: map[string]any{
+				"type": "SystemAssigned",
+			},
 			expectedValue: "SystemAssigned",
 		},
 	}
 	for i, v := range testData {
 		t.Logf("step %d..", i)
 
-		encoded, err := v.input.MarshalJSON()
+		encoded, err := json.Marshal(v.input)
 		if err != nil {
 			t.Fatalf("marshaling: %+v", err)
+		}
+
+		expectEncoded, _ := json.Marshal(v.expect)
+		if string(encoded) != string(expectEncoded) {
+			t.Fatalf("marshaled JSON is not as expected. got=%v, expect=%v", string(encoded), string(expectEncoded))
 		}
 
 		var out map[string]interface{}

--- a/resourcemanager/identity/system_assigned_test.go
+++ b/resourcemanager/identity/system_assigned_test.go
@@ -76,9 +76,19 @@ func TestSystemAssignedMarshal(t *testing.T) {
 			t.Fatalf("marshaling: %+v", err)
 		}
 
+		encodedDirect, err := v.input.(json.Marshaler).MarshalJSON()
+		if err != nil {
+			t.Fatalf("direct marshaling: %+v", err)
+		}
+
 		expectEncoded, _ := json.Marshal(v.expect)
+
 		if string(encoded) != string(expectEncoded) {
 			t.Fatalf("marshaled JSON is not as expected. got=%v, expect=%v", string(encoded), string(expectEncoded))
+		}
+
+		if string(encodedDirect) != string(expectEncoded) {
+			t.Fatalf("direct marshaled JSON is not as expected. got=%v, expect=%v", string(encodedDirect), string(expectEncoded))
 		}
 
 		var out map[string]interface{}
@@ -90,5 +100,6 @@ func TestSystemAssignedMarshal(t *testing.T) {
 		if v.expectedValue != actualValue {
 			t.Fatalf("expected %q but got %q", v.expectedValue, actualValue)
 		}
+
 	}
 }

--- a/resourcemanager/identity/system_or_user_assigned_list.go
+++ b/resourcemanager/identity/system_or_user_assigned_list.go
@@ -20,22 +20,20 @@ type SystemOrUserAssignedList struct {
 	IdentityIds []string `json:"userAssignedIdentities" tfschema:"identity_ids"`
 }
 
-func (s *SystemOrUserAssignedList) MarshalJSON() ([]byte, error) {
+func (s SystemOrUserAssignedList) MarshalJSON() ([]byte, error) {
 	// we use a custom marshal function here since we can only send the Type / UserAssignedIdentities field
 	identityType := TypeNone
 	userAssignedIdentityIds := []string{}
 
-	if s != nil {
-		if s.Type == TypeSystemAssigned {
-			identityType = TypeSystemAssigned
-		}
-		if s.Type == TypeUserAssigned {
-			identityType = TypeUserAssigned
-		}
+	if s.Type == TypeSystemAssigned {
+		identityType = TypeSystemAssigned
+	}
+	if s.Type == TypeUserAssigned {
+		identityType = TypeUserAssigned
+	}
 
-		if identityType != TypeNone {
-			userAssignedIdentityIds = s.IdentityIds
-		}
+	if identityType != TypeNone {
+		userAssignedIdentityIds = s.IdentityIds
 	}
 
 	out := map[string]interface{}{

--- a/resourcemanager/identity/system_or_user_assigned_list_test.go
+++ b/resourcemanager/identity/system_or_user_assigned_list_test.go
@@ -150,9 +150,19 @@ func TestSystemOrUserAssignedListMarshal(t *testing.T) {
 			t.Fatalf("marshaling: %+v", err)
 		}
 
+		encodedDirect, err := v.input.(json.Marshaler).MarshalJSON()
+		if err != nil {
+			t.Fatalf("direct marshaling: %+v", err)
+		}
+
 		expectEncoded, _ := json.Marshal(v.expect)
+
 		if string(encoded) != string(expectEncoded) {
 			t.Fatalf("marshaled JSON is not as expected. got=%v, expect=%v", string(encoded), string(expectEncoded))
+		}
+
+		if string(encodedDirect) != string(expectEncoded) {
+			t.Fatalf("direct marshaled JSON is not as expected. got=%v, expect=%v", string(encodedDirect), string(expectEncoded))
 		}
 
 		var out map[string]interface{}

--- a/resourcemanager/identity/system_or_user_assigned_list_test.go
+++ b/resourcemanager/identity/system_or_user_assigned_list_test.go
@@ -12,23 +12,27 @@ import (
 
 func TestSystemOrUserAssignedListMarshal(t *testing.T) {
 	testData := []struct {
-		input                           *SystemOrUserAssignedList
+		input                           any
+		expect                          map[string]any
 		expectedIdentityType            string
 		expectedUserAssignedIdentityIds []string
 	}{
 		{
-			input:                           nil,
-			expectedIdentityType:            "None",
-			expectedUserAssignedIdentityIds: []string{},
-		},
-		{
-			input:                           &SystemOrUserAssignedList{},
+			input: &SystemOrUserAssignedList{},
+			expect: map[string]any{
+				"type":                   "None",
+				"userAssignedIdentities": nil,
+			},
 			expectedIdentityType:            "None",
 			expectedUserAssignedIdentityIds: []string{},
 		},
 		{
 			input: &SystemOrUserAssignedList{
 				Type: TypeNone,
+			},
+			expect: map[string]any{
+				"type":                   "None",
+				"userAssignedIdentities": nil,
 			},
 			expectedIdentityType:            "None",
 			expectedUserAssignedIdentityIds: []string{},
@@ -40,6 +44,10 @@ func TestSystemOrUserAssignedListMarshal(t *testing.T) {
 					"first",
 				},
 			},
+			expect: map[string]any{
+				"type":                   "None",
+				"userAssignedIdentities": nil,
+			},
 			expectedIdentityType:            "None",
 			expectedUserAssignedIdentityIds: []string{
 				// intentionally empty since this is bad data
@@ -50,6 +58,23 @@ func TestSystemOrUserAssignedListMarshal(t *testing.T) {
 				Type:        TypeSystemAssigned,
 				IdentityIds: []string{},
 			},
+			expect: map[string]any{
+				"type":                   "SystemAssigned",
+				"userAssignedIdentities": nil,
+			},
+			expectedIdentityType:            "SystemAssigned",
+			expectedUserAssignedIdentityIds: []string{},
+		},
+		{
+			// Value type (instead of pointer type)
+			input: SystemOrUserAssignedList{
+				Type:        TypeSystemAssigned,
+				IdentityIds: []string{},
+			},
+			expect: map[string]any{
+				"type":                   "SystemAssigned",
+				"userAssignedIdentities": nil,
+			},
 			expectedIdentityType:            "SystemAssigned",
 			expectedUserAssignedIdentityIds: []string{},
 		},
@@ -58,6 +83,10 @@ func TestSystemOrUserAssignedListMarshal(t *testing.T) {
 				Type:        TypeSystemAssignedUserAssigned,
 				IdentityIds: []string{},
 			},
+			expect: map[string]any{
+				"type":                   "None",
+				"userAssignedIdentities": nil,
+			},
 			expectedIdentityType:            "None",
 			expectedUserAssignedIdentityIds: []string{},
 		},
@@ -65,6 +94,10 @@ func TestSystemOrUserAssignedListMarshal(t *testing.T) {
 			input: &SystemOrUserAssignedList{
 				Type:        TypeUserAssigned,
 				IdentityIds: []string{},
+			},
+			expect: map[string]any{
+				"type":                   "UserAssigned",
+				"userAssignedIdentities": nil,
 			},
 			expectedIdentityType:            "UserAssigned",
 			expectedUserAssignedIdentityIds: []string{},
@@ -77,6 +110,10 @@ func TestSystemOrUserAssignedListMarshal(t *testing.T) {
 					"first",
 					"second",
 				},
+			},
+			expect: map[string]any{
+				"type":                   "None",
+				"userAssignedIdentities": nil,
 			},
 			expectedIdentityType:            "None",
 			expectedUserAssignedIdentityIds: []string{
@@ -91,6 +128,13 @@ func TestSystemOrUserAssignedListMarshal(t *testing.T) {
 					"second",
 				},
 			},
+			expect: map[string]any{
+				"type": "UserAssigned",
+				"userAssignedIdentities": []any{
+					"first",
+					"second",
+				},
+			},
 			expectedIdentityType: "UserAssigned",
 			expectedUserAssignedIdentityIds: []string{
 				"first",
@@ -101,9 +145,14 @@ func TestSystemOrUserAssignedListMarshal(t *testing.T) {
 	for i, v := range testData {
 		t.Logf("step %d..", i)
 
-		encoded, err := v.input.MarshalJSON()
+		encoded, err := json.Marshal(v.input)
 		if err != nil {
 			t.Fatalf("marshaling: %+v", err)
+		}
+
+		expectEncoded, _ := json.Marshal(v.expect)
+		if string(encoded) != string(expectEncoded) {
+			t.Fatalf("marshaled JSON is not as expected. got=%v, expect=%v", string(encoded), string(expectEncoded))
 		}
 
 		var out map[string]interface{}

--- a/resourcemanager/identity/system_or_user_assigned_map.go
+++ b/resourcemanager/identity/system_or_user_assigned_map.go
@@ -20,22 +20,20 @@ type SystemOrUserAssignedMap struct {
 	IdentityIds map[string]UserAssignedIdentityDetails `json:"userAssignedIdentities"`
 }
 
-func (s *SystemOrUserAssignedMap) MarshalJSON() ([]byte, error) {
+func (s SystemOrUserAssignedMap) MarshalJSON() ([]byte, error) {
 	// we use a custom marshal function here since we can only send the Type / UserAssignedIdentities field
 	identityType := TypeNone
 	userAssignedIdentityIds := map[string]UserAssignedIdentityDetails{}
 
-	if s != nil {
-		if s.Type == TypeSystemAssigned {
-			identityType = TypeSystemAssigned
-		}
-		if s.Type == TypeUserAssigned {
-			identityType = TypeUserAssigned
-		}
+	if s.Type == TypeSystemAssigned {
+		identityType = TypeSystemAssigned
+	}
+	if s.Type == TypeUserAssigned {
+		identityType = TypeUserAssigned
+	}
 
-		if identityType != TypeNone {
-			userAssignedIdentityIds = s.IdentityIds
-		}
+	if identityType != TypeNone {
+		userAssignedIdentityIds = s.IdentityIds
 	}
 
 	out := map[string]interface{}{

--- a/resourcemanager/identity/system_or_user_assigned_map_test.go
+++ b/resourcemanager/identity/system_or_user_assigned_map_test.go
@@ -13,23 +13,27 @@ import (
 
 func TestSystemOrUserAssignedMapMarshal(t *testing.T) {
 	testData := []struct {
-		input                           *SystemOrUserAssignedMap
+		input                           any
+		expect                          map[string]any
 		expectedIdentityType            string
 		expectedUserAssignedIdentityIds []string
 	}{
 		{
-			input:                           nil,
-			expectedIdentityType:            "None",
-			expectedUserAssignedIdentityIds: []string{},
-		},
-		{
-			input:                           &SystemOrUserAssignedMap{},
+			input: &SystemOrUserAssignedMap{},
+			expect: map[string]any{
+				"type":                   "None",
+				"userAssignedIdentities": nil,
+			},
 			expectedIdentityType:            "None",
 			expectedUserAssignedIdentityIds: []string{},
 		},
 		{
 			input: &SystemOrUserAssignedMap{
 				Type: TypeNone,
+			},
+			expect: map[string]any{
+				"type":                   "None",
+				"userAssignedIdentities": nil,
 			},
 			expectedIdentityType:            "None",
 			expectedUserAssignedIdentityIds: []string{},
@@ -41,6 +45,10 @@ func TestSystemOrUserAssignedMapMarshal(t *testing.T) {
 					"first": {},
 				},
 			},
+			expect: map[string]any{
+				"type":                   "None",
+				"userAssignedIdentities": nil,
+			},
 			expectedIdentityType:            "None",
 			expectedUserAssignedIdentityIds: []string{
 				// intentionally empty since this is bad data
@@ -51,6 +59,23 @@ func TestSystemOrUserAssignedMapMarshal(t *testing.T) {
 				Type:        TypeSystemAssigned,
 				IdentityIds: map[string]UserAssignedIdentityDetails{},
 			},
+			expect: map[string]any{
+				"type":                   "SystemAssigned",
+				"userAssignedIdentities": nil,
+			},
+			expectedIdentityType:            "SystemAssigned",
+			expectedUserAssignedIdentityIds: []string{},
+		},
+		{
+			// Value type (instead of pointer type)
+			input: SystemOrUserAssignedMap{
+				Type:        TypeSystemAssigned,
+				IdentityIds: map[string]UserAssignedIdentityDetails{},
+			},
+			expect: map[string]any{
+				"type":                   "SystemAssigned",
+				"userAssignedIdentities": nil,
+			},
 			expectedIdentityType:            "SystemAssigned",
 			expectedUserAssignedIdentityIds: []string{},
 		},
@@ -59,6 +84,10 @@ func TestSystemOrUserAssignedMapMarshal(t *testing.T) {
 				Type:        TypeSystemAssignedUserAssigned,
 				IdentityIds: map[string]UserAssignedIdentityDetails{},
 			},
+			expect: map[string]any{
+				"type":                   "None",
+				"userAssignedIdentities": nil,
+			},
 			expectedIdentityType:            "None",
 			expectedUserAssignedIdentityIds: []string{},
 		},
@@ -66,6 +95,10 @@ func TestSystemOrUserAssignedMapMarshal(t *testing.T) {
 			input: &SystemOrUserAssignedMap{
 				Type:        TypeUserAssigned,
 				IdentityIds: map[string]UserAssignedIdentityDetails{},
+			},
+			expect: map[string]any{
+				"type":                   "UserAssigned",
+				"userAssignedIdentities": nil,
 			},
 			expectedIdentityType:            "UserAssigned",
 			expectedUserAssignedIdentityIds: []string{},
@@ -78,6 +111,10 @@ func TestSystemOrUserAssignedMapMarshal(t *testing.T) {
 					"first":  {},
 					"second": {},
 				},
+			},
+			expect: map[string]any{
+				"type":                   "None",
+				"userAssignedIdentities": nil,
 			},
 			expectedIdentityType:            "None",
 			expectedUserAssignedIdentityIds: []string{
@@ -92,6 +129,13 @@ func TestSystemOrUserAssignedMapMarshal(t *testing.T) {
 					"second": {},
 				},
 			},
+			expect: map[string]any{
+				"type": "UserAssigned",
+				"userAssignedIdentities": map[string]any{
+					"first":  map[string]any{},
+					"second": map[string]any{},
+				},
+			},
 			expectedIdentityType: "UserAssigned",
 			expectedUserAssignedIdentityIds: []string{
 				"first",
@@ -102,9 +146,14 @@ func TestSystemOrUserAssignedMapMarshal(t *testing.T) {
 	for i, v := range testData {
 		t.Logf("step %d..", i)
 
-		encoded, err := v.input.MarshalJSON()
+		encoded, err := json.Marshal(v.input)
 		if err != nil {
 			t.Fatalf("marshaling: %+v", err)
+		}
+
+		expectEncoded, _ := json.Marshal(v.expect)
+		if string(encoded) != string(expectEncoded) {
+			t.Fatalf("marshaled JSON is not as expected. got=%v, expect=%v", string(encoded), string(expectEncoded))
 		}
 
 		var out map[string]interface{}

--- a/resourcemanager/identity/system_or_user_assigned_map_test.go
+++ b/resourcemanager/identity/system_or_user_assigned_map_test.go
@@ -151,9 +151,19 @@ func TestSystemOrUserAssignedMapMarshal(t *testing.T) {
 			t.Fatalf("marshaling: %+v", err)
 		}
 
+		encodedDirect, err := v.input.(json.Marshaler).MarshalJSON()
+		if err != nil {
+			t.Fatalf("direct marshaling: %+v", err)
+		}
+
 		expectEncoded, _ := json.Marshal(v.expect)
+
 		if string(encoded) != string(expectEncoded) {
 			t.Fatalf("marshaled JSON is not as expected. got=%v, expect=%v", string(encoded), string(expectEncoded))
+		}
+
+		if string(encodedDirect) != string(expectEncoded) {
+			t.Fatalf("direct marshaled JSON is not as expected. got=%v, expect=%v", string(encodedDirect), string(expectEncoded))
 		}
 
 		var out map[string]interface{}

--- a/resourcemanager/identity/user_assigned_list.go
+++ b/resourcemanager/identity/user_assigned_list.go
@@ -18,16 +18,14 @@ type UserAssignedList struct {
 	IdentityIds []string `json:"userAssignedIdentities" tfschema:"identity_ids"`
 }
 
-func (s *UserAssignedList) MarshalJSON() ([]byte, error) {
+func (s UserAssignedList) MarshalJSON() ([]byte, error) {
 	// we use a custom marshal function here since we can only send the Type / UserAssignedIdentities field
 	identityType := TypeNone
 	userAssignedIdentityIds := []string{}
 
-	if s != nil {
-		if s.Type == TypeUserAssigned {
-			identityType = TypeUserAssigned
-			userAssignedIdentityIds = s.IdentityIds
-		}
+	if s.Type == TypeUserAssigned {
+		identityType = TypeUserAssigned
+		userAssignedIdentityIds = s.IdentityIds
 	}
 
 	out := map[string]interface{}{

--- a/resourcemanager/identity/user_assigned_list_test.go
+++ b/resourcemanager/identity/user_assigned_list_test.go
@@ -150,9 +150,19 @@ func TestUserAssignedListMarshal(t *testing.T) {
 			t.Fatalf("marshaling: %+v", err)
 		}
 
+		encodedDirect, err := v.input.(json.Marshaler).MarshalJSON()
+		if err != nil {
+			t.Fatalf("direct marshaling: %+v", err)
+		}
+
 		expectEncoded, _ := json.Marshal(v.expect)
+
 		if string(encoded) != string(expectEncoded) {
 			t.Fatalf("marshaled JSON is not as expected. got=%v, expect=%v", string(encoded), string(expectEncoded))
+		}
+
+		if string(encodedDirect) != string(expectEncoded) {
+			t.Fatalf("direct marshaled JSON is not as expected. got=%v, expect=%v", string(encodedDirect), string(expectEncoded))
 		}
 
 		var out map[string]interface{}

--- a/resourcemanager/identity/user_assigned_list_test.go
+++ b/resourcemanager/identity/user_assigned_list_test.go
@@ -12,23 +12,27 @@ import (
 
 func TestUserAssignedListMarshal(t *testing.T) {
 	testData := []struct {
-		input                           *UserAssignedList
+		input                           any
+		expect                          map[string]any
 		expectedIdentityType            string
 		expectedUserAssignedIdentityIds []string
 	}{
 		{
-			input:                           nil,
-			expectedIdentityType:            "None",
-			expectedUserAssignedIdentityIds: []string{},
-		},
-		{
-			input:                           &UserAssignedList{},
+			input: &UserAssignedList{},
+			expect: map[string]any{
+				"type":                   "None",
+				"userAssignedIdentities": nil,
+			},
 			expectedIdentityType:            "None",
 			expectedUserAssignedIdentityIds: []string{},
 		},
 		{
 			input: &UserAssignedList{
 				Type: TypeNone,
+			},
+			expect: map[string]any{
+				"type":                   "None",
+				"userAssignedIdentities": nil,
 			},
 			expectedIdentityType:            "None",
 			expectedUserAssignedIdentityIds: []string{},
@@ -40,6 +44,10 @@ func TestUserAssignedListMarshal(t *testing.T) {
 					"first",
 				},
 			},
+			expect: map[string]any{
+				"type":                   "None",
+				"userAssignedIdentities": nil,
+			},
 			expectedIdentityType:            "None",
 			expectedUserAssignedIdentityIds: []string{
 				// intentionally empty since this is bad data
@@ -50,6 +58,10 @@ func TestUserAssignedListMarshal(t *testing.T) {
 				Type:        TypeSystemAssigned,
 				IdentityIds: []string{},
 			},
+			expect: map[string]any{
+				"type":                   "None",
+				"userAssignedIdentities": nil,
+			},
 			expectedIdentityType:            "None",
 			expectedUserAssignedIdentityIds: []string{},
 		},
@@ -58,6 +70,10 @@ func TestUserAssignedListMarshal(t *testing.T) {
 				Type:        TypeSystemAssignedUserAssigned,
 				IdentityIds: []string{},
 			},
+			expect: map[string]any{
+				"type":                   "None",
+				"userAssignedIdentities": nil,
+			},
 			expectedIdentityType:            "None",
 			expectedUserAssignedIdentityIds: []string{},
 		},
@@ -65,6 +81,23 @@ func TestUserAssignedListMarshal(t *testing.T) {
 			input: &UserAssignedList{
 				Type:        TypeUserAssigned,
 				IdentityIds: []string{},
+			},
+			expect: map[string]any{
+				"type":                   "UserAssigned",
+				"userAssignedIdentities": nil,
+			},
+			expectedIdentityType:            "UserAssigned",
+			expectedUserAssignedIdentityIds: []string{},
+		},
+		{
+			// Value type (instead of pointer type)
+			input: UserAssignedList{
+				Type:        TypeUserAssigned,
+				IdentityIds: []string{},
+			},
+			expect: map[string]any{
+				"type":                   "UserAssigned",
+				"userAssignedIdentities": nil,
 			},
 			expectedIdentityType:            "UserAssigned",
 			expectedUserAssignedIdentityIds: []string{},
@@ -77,6 +110,10 @@ func TestUserAssignedListMarshal(t *testing.T) {
 					"first",
 					"second",
 				},
+			},
+			expect: map[string]any{
+				"type":                   "None",
+				"userAssignedIdentities": nil,
 			},
 			expectedIdentityType:            "None",
 			expectedUserAssignedIdentityIds: []string{
@@ -91,6 +128,13 @@ func TestUserAssignedListMarshal(t *testing.T) {
 					"second",
 				},
 			},
+			expect: map[string]any{
+				"type": "UserAssigned",
+				"userAssignedIdentities": []any{
+					"first",
+					"second",
+				},
+			},
 			expectedIdentityType: "UserAssigned",
 			expectedUserAssignedIdentityIds: []string{
 				"first",
@@ -101,9 +145,14 @@ func TestUserAssignedListMarshal(t *testing.T) {
 	for i, v := range testData {
 		t.Logf("step %d..", i)
 
-		encoded, err := v.input.MarshalJSON()
+		encoded, err := json.Marshal(v.input)
 		if err != nil {
 			t.Fatalf("marshaling: %+v", err)
+		}
+
+		expectEncoded, _ := json.Marshal(v.expect)
+		if string(encoded) != string(expectEncoded) {
+			t.Fatalf("marshaled JSON is not as expected. got=%v, expect=%v", string(encoded), string(expectEncoded))
 		}
 
 		var out map[string]interface{}

--- a/resourcemanager/identity/user_assigned_map.go
+++ b/resourcemanager/identity/user_assigned_map.go
@@ -18,16 +18,14 @@ type UserAssignedMap struct {
 	IdentityIds map[string]UserAssignedIdentityDetails `json:"userAssignedIdentities"`
 }
 
-func (s *UserAssignedMap) MarshalJSON() ([]byte, error) {
+func (s UserAssignedMap) MarshalJSON() ([]byte, error) {
 	// we use a custom marshal function here since we can only send the Type / UserAssignedIdentities field
 	identityType := TypeNone
 	userAssignedIdentityIds := map[string]UserAssignedIdentityDetails{}
 
-	if s != nil {
-		if s.Type == TypeUserAssigned {
-			identityType = TypeUserAssigned
-			userAssignedIdentityIds = s.IdentityIds
-		}
+	if s.Type == TypeUserAssigned {
+		identityType = TypeUserAssigned
+		userAssignedIdentityIds = s.IdentityIds
 	}
 
 	out := map[string]interface{}{

--- a/resourcemanager/identity/user_assigned_map_test.go
+++ b/resourcemanager/identity/user_assigned_map_test.go
@@ -13,23 +13,27 @@ import (
 
 func TestUserAssignedMapMarshal(t *testing.T) {
 	testData := []struct {
-		input                           *UserAssignedMap
+		input                           any
+		expect                          map[string]any
 		expectedIdentityType            string
 		expectedUserAssignedIdentityIds []string
 	}{
 		{
-			input:                           nil,
-			expectedIdentityType:            "None",
-			expectedUserAssignedIdentityIds: []string{},
-		},
-		{
-			input:                           &UserAssignedMap{},
+			input: &UserAssignedMap{},
+			expect: map[string]any{
+				"type":                   "None",
+				"userAssignedIdentities": nil,
+			},
 			expectedIdentityType:            "None",
 			expectedUserAssignedIdentityIds: []string{},
 		},
 		{
 			input: &UserAssignedMap{
 				Type: TypeNone,
+			},
+			expect: map[string]any{
+				"type":                   "None",
+				"userAssignedIdentities": nil,
 			},
 			expectedIdentityType:            "None",
 			expectedUserAssignedIdentityIds: []string{},
@@ -41,6 +45,10 @@ func TestUserAssignedMapMarshal(t *testing.T) {
 					"first": {},
 				},
 			},
+			expect: map[string]any{
+				"type":                   "None",
+				"userAssignedIdentities": nil,
+			},
 			expectedIdentityType:            "None",
 			expectedUserAssignedIdentityIds: []string{
 				// intentionally empty since this is bad data
@@ -51,6 +59,10 @@ func TestUserAssignedMapMarshal(t *testing.T) {
 				Type:        TypeSystemAssigned,
 				IdentityIds: map[string]UserAssignedIdentityDetails{},
 			},
+			expect: map[string]any{
+				"type":                   "None",
+				"userAssignedIdentities": nil,
+			},
 			expectedIdentityType:            "None",
 			expectedUserAssignedIdentityIds: []string{},
 		},
@@ -59,6 +71,10 @@ func TestUserAssignedMapMarshal(t *testing.T) {
 				Type:        TypeSystemAssignedUserAssigned,
 				IdentityIds: map[string]UserAssignedIdentityDetails{},
 			},
+			expect: map[string]any{
+				"type":                   "None",
+				"userAssignedIdentities": nil,
+			},
 			expectedIdentityType:            "None",
 			expectedUserAssignedIdentityIds: []string{},
 		},
@@ -66,6 +82,23 @@ func TestUserAssignedMapMarshal(t *testing.T) {
 			input: &UserAssignedMap{
 				Type:        TypeUserAssigned,
 				IdentityIds: map[string]UserAssignedIdentityDetails{},
+			},
+			expect: map[string]any{
+				"type":                   "UserAssigned",
+				"userAssignedIdentities": nil,
+			},
+			expectedIdentityType:            "UserAssigned",
+			expectedUserAssignedIdentityIds: []string{},
+		},
+		{
+			// Value type (instead of pointer type)
+			input: UserAssignedMap{
+				Type:        TypeUserAssigned,
+				IdentityIds: map[string]UserAssignedIdentityDetails{},
+			},
+			expect: map[string]any{
+				"type":                   "UserAssigned",
+				"userAssignedIdentities": nil,
 			},
 			expectedIdentityType:            "UserAssigned",
 			expectedUserAssignedIdentityIds: []string{},
@@ -78,6 +111,10 @@ func TestUserAssignedMapMarshal(t *testing.T) {
 					"first":  {},
 					"second": {},
 				},
+			},
+			expect: map[string]any{
+				"type":                   "None",
+				"userAssignedIdentities": nil,
 			},
 			expectedIdentityType:            "None",
 			expectedUserAssignedIdentityIds: []string{
@@ -92,6 +129,13 @@ func TestUserAssignedMapMarshal(t *testing.T) {
 					"second": {},
 				},
 			},
+			expect: map[string]any{
+				"type": "UserAssigned",
+				"userAssignedIdentities": map[string]any{
+					"first":  map[string]any{},
+					"second": map[string]any{},
+				},
+			},
 			expectedIdentityType: "UserAssigned",
 			expectedUserAssignedIdentityIds: []string{
 				"first",
@@ -102,9 +146,14 @@ func TestUserAssignedMapMarshal(t *testing.T) {
 	for i, v := range testData {
 		t.Logf("step %d..", i)
 
-		encoded, err := v.input.MarshalJSON()
+		encoded, err := json.Marshal(v.input)
 		if err != nil {
 			t.Fatalf("marshaling: %+v", err)
+		}
+
+		expectEncoded, _ := json.Marshal(v.expect)
+		if string(encoded) != string(expectEncoded) {
+			t.Fatalf("marshaled JSON is not as expected. got=%v, expect=%v", string(encoded), string(expectEncoded))
 		}
 
 		var out map[string]interface{}

--- a/resourcemanager/identity/user_assigned_map_test.go
+++ b/resourcemanager/identity/user_assigned_map_test.go
@@ -151,9 +151,19 @@ func TestUserAssignedMapMarshal(t *testing.T) {
 			t.Fatalf("marshaling: %+v", err)
 		}
 
+		encodedDirect, err := v.input.(json.Marshaler).MarshalJSON()
+		if err != nil {
+			t.Fatalf("direct marshaling: %+v", err)
+		}
+
 		expectEncoded, _ := json.Marshal(v.expect)
+
 		if string(encoded) != string(expectEncoded) {
 			t.Fatalf("marshaled JSON is not as expected. got=%v, expect=%v", string(encoded), string(expectEncoded))
+		}
+
+		if string(encodedDirect) != string(expectEncoded) {
+			t.Fatalf("direct marshaled JSON is not as expected. got=%v, expect=%v", string(encodedDirect), string(expectEncoded))
 		}
 
 		var out map[string]interface{}


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 
If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Per https://go.dev/doc/effective_go#pointers_vs_values:

> The rule about pointers vs. values for receivers is that value methods can be invoked on pointers and values, but pointer methods can only be invoked on pointers.
> ...There is a handy exception, though. When the value is addressable, the language takes care of the common case of invoking a pointer method on a value by inserting the address operator automatically.

In the `json.Marshal()`, it will check each field's type whether it implements the `json.Marshler`. The pointer of the identity types implement it, while the value types are not, which causes the member identity field to fall back to the default marshal logic.

This issue was detected when implementing a resource (Storage Actions Task), where its Swagger declares the `identity` as required. The generated go-azure-sdk then defines the `identity` field as an identity type, instead of an identity pointer type.

This PR changes the receiver from pointer to value type. Together with updated test cases, which:

- Removes the nil input test case, which will always be marshaled into `null` by json.Marshal
- Changes the call to `json.Marshal` instead of direct call to MarshalJSON to make it more of a real use case
- Add a new test step that the `input` is a value type to cover this new issue
- Add an `expect` verification facet (arguably we shall remove the other verification facets as some tests will involve a customized Unmarshal).


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* added new function `AFunction` [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
