### PR TITLE
resourceids - update interface and update CompositeResourceID to implement it

### DIFF
--- a/resourcemanager/commonids/composite_resource_id.go
+++ b/resourcemanager/commonids/composite_resource_id.go
@@ -43,8 +43,8 @@ func (id CompositeResourceID[T1, T2]) FromParseResult(_ resourceids.ParseResult)
 
 func (id CompositeResourceID[T1, T2]) Segments() []resourceids.Segment {
 	return []resourceids.Segment{
-		resourceids.ResourceIDSegment("resourceID1", id.First.ID()),
-		resourceids.ResourceIDSegment("resourceID2", id.Second.ID()),
+		resourceids.ResourceIDSegment("resourceID1", resourceids.BuildExpectedResourceId(id.First.Segments())),
+		resourceids.ResourceIDSegment("resourceID2", resourceids.BuildExpectedResourceId(id.Second.Segments())),
 	}
 }
 

--- a/resourcemanager/commonids/composite_resource_id.go
+++ b/resourcemanager/commonids/composite_resource_id.go
@@ -10,15 +10,42 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 )
 
+var _ resourceids.ResourceId = CompositeResourceID[resourceids.ResourceId, resourceids.ResourceId]{}
+
 // CompositeResourceID is a struct representing the Resource ID for a Composite Resource Id
 type CompositeResourceID[T1 resourceids.ResourceId, T2 resourceids.ResourceId] struct {
 	// First specifies the first component of this Resource ID.
 	// This is in the format `{first}|{second}`.
-	First T1
+	First            T1
+	firstParseResult *resourceids.ParseResult
 
 	// Second specifies the second component of this Resource ID
 	// This is in the format `{first}|{second}`.
-	Second T2
+	Second            T2
+	secondParseResult *resourceids.ParseResult
+}
+
+func (id CompositeResourceID[T1, T2]) FromParseResult(_ resourceids.ParseResult) error {
+	if id.firstParseResult != nil {
+		if err := id.First.FromParseResult(*id.firstParseResult); err != nil {
+			fmt.Errorf("populating first ID (%s) of CompositeResourceID: %v", id.First.ID(), err)
+		}
+	}
+
+	if id.secondParseResult != nil {
+		if err := id.Second.FromParseResult(*id.secondParseResult); err != nil {
+			fmt.Errorf("populating second ID (%s) of CompositeResourceID: %v", id.Second.ID(), err)
+		}
+	}
+
+	return nil
+}
+
+func (id CompositeResourceID[T1, T2]) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.ResourceIDSegment("resourceID1", id.First.ID()),
+		resourceids.ResourceIDSegment("resourceID2", id.Second.ID()),
+	}
 }
 
 // NewCompositeResourceID returns a new CompositeResourceID struct
@@ -78,10 +105,7 @@ func parseCompositeResourceID[T1 resourceids.ResourceId, T2 resourceids.Resource
 	if err != nil {
 		return nil, fmt.Errorf("parsing first id part %q of CompositeResourceID: %v", components[0], err)
 	}
-	err = output.First.FromParseResult(*firstParseResult)
-	if err != nil {
-		return nil, fmt.Errorf("populating first id part %q of CompositeResourceID: %v", components[0], err)
-	}
+	output.firstParseResult = firstParseResult
 
 	// Parse the second of the two Resource IDs from the components
 	secondParser := resourceids.NewParserFromResourceIdType(output.Second)
@@ -89,9 +113,12 @@ func parseCompositeResourceID[T1 resourceids.ResourceId, T2 resourceids.Resource
 	if err != nil {
 		return nil, fmt.Errorf("parsing second id part %q of CompositeResourceID: %v", components[1], err)
 	}
-	err = output.Second.FromParseResult(*secondParseResult)
-	if err != nil {
-		return nil, fmt.Errorf("populating second id part %q of CompositeResourceID: %v", components[1], err)
+	output.secondParseResult = secondParseResult
+
+	// Pass the `firstParseResult` as the parameter is required to satisfy the `resourceId` interface
+	// internally, this function discards the input and uses the previously stored results.
+	if err := output.FromParseResult(*firstParseResult); err != nil {
+		return nil, err
 	}
 
 	return &output, nil

--- a/resourcemanager/commonids/composite_resource_id.go
+++ b/resourcemanager/commonids/composite_resource_id.go
@@ -28,13 +28,13 @@ type CompositeResourceID[T1 resourceids.ResourceId, T2 resourceids.ResourceId] s
 func (id CompositeResourceID[T1, T2]) FromParseResult(_ resourceids.ParseResult) error {
 	if id.firstParseResult != nil {
 		if err := id.First.FromParseResult(*id.firstParseResult); err != nil {
-			fmt.Errorf("populating first ID (%s) of CompositeResourceID: %v", id.First.ID(), err)
+			return fmt.Errorf("populating first ID (%s) of CompositeResourceID: %v", id.First.ID(), err)
 		}
 	}
 
 	if id.secondParseResult != nil {
 		if err := id.Second.FromParseResult(*id.secondParseResult); err != nil {
-			fmt.Errorf("populating second ID (%s) of CompositeResourceID: %v", id.Second.ID(), err)
+			return fmt.Errorf("populating second ID (%s) of CompositeResourceID: %v", id.Second.ID(), err)
 		}
 	}
 

--- a/resourcemanager/resourceids/error_number_of_segments_didnt_match.go
+++ b/resourcemanager/resourceids/error_number_of_segments_didnt_match.go
@@ -33,7 +33,7 @@ func NewNumberOfSegmentsDidntMatchError(id ResourceId, parseResult ParseResult) 
 
 // Error returns a detailed error message highlighting the issues found when parsing this Resource ID Segment.
 func (e NumberOfSegmentsDidntMatchError) Error() string {
-	expectedId := buildExpectedResourceId(e.resourceId.Segments())
+	expectedId := BuildExpectedResourceId(e.resourceId.Segments())
 
 	description, err := descriptionForSegments(e.resourceId.Segments())
 	if err != nil {

--- a/resourcemanager/resourceids/error_segment_not_specified.go
+++ b/resourcemanager/resourceids/error_segment_not_specified.go
@@ -36,7 +36,7 @@ func NewSegmentNotSpecifiedError(id ResourceId, segmentName string, parseResult 
 
 // Error returns a detailed error message highlighting the issues found when parsing this Resource ID Segment.
 func (e SegmentNotSpecifiedError) Error() string {
-	expectedId := buildExpectedResourceId(e.resourceId.Segments())
+	expectedId := BuildExpectedResourceId(e.resourceId.Segments())
 	position := findPositionOfSegment(e.segmentName, e.resourceId.Segments())
 	if position == nil {
 		return fmt.Sprintf("internal-error: couldn't determine the position for segment %q", e.segmentName)

--- a/resourcemanager/resourceids/errors.go
+++ b/resourcemanager/resourceids/errors.go
@@ -8,6 +8,18 @@ import (
 	"strings"
 )
 
+// BuildExpectedResourceId iterates over the Resource ID to build up the "expected" value for the Resource ID
+// this is done using the example segment values for each segment type.
+func BuildExpectedResourceId(segments []Segment) string {
+	components := make([]string, 0)
+	for _, v := range segments {
+		components = append(components, strings.TrimPrefix(v.ExampleValue, "/"))
+	}
+
+	out := strings.Join(components, "/")
+	return fmt.Sprintf("/%s", out)
+}
+
 // descriptionForSegments returns a summary/description for the provided Resource ID Segments
 func descriptionForSegments(input []Segment) (*string, error) {
 	lines := make([]string, 0)
@@ -101,18 +113,6 @@ func descriptionForSpecifiedSegment(segment Segment) (*string, error) {
 	}
 
 	return nil, fmt.Errorf("internal-error: the Segment Type %q was not implemented for Segment %q", string(segment.Type), segment.Name)
-}
-
-// buildExpectedResourceId iterates over the Resource ID to build up the "expected" value for the Resource ID
-// this is done using the example segment values for each segment type.
-func buildExpectedResourceId(segments []Segment) string {
-	components := make([]string, 0)
-	for _, v := range segments {
-		components = append(components, strings.TrimPrefix(v.ExampleValue, "/"))
-	}
-
-	out := strings.Join(components, "/")
-	return fmt.Sprintf("/%s", out)
 }
 
 // findPositionOfSegment returns the position of the segment specified by segmentName within segments

--- a/resourcemanager/resourceids/interface.go
+++ b/resourcemanager/resourceids/interface.go
@@ -65,6 +65,9 @@ const (
 
 	// DataPlaneBaseURISegmentType specifies that this Segment is a Data Plane Endpoint URI for a resource type
 	DataPlaneBaseURISegmentType SegmentType = "DataPlane"
+
+	// ResourceIDSegmentType specifies that this Segment is a complete Resource ID
+	ResourceIDSegmentType SegmentType = "ResourceID"
 )
 
 // ConstantSegment is a helper which returns a Segment for a Constant
@@ -139,6 +142,16 @@ func DataPlaneBaseURISegment(name, exampleValue string) Segment {
 	return Segment{
 		Name:         name,
 		Type:         DataPlaneBaseURISegmentType,
+		ExampleValue: exampleValue,
+	}
+}
+
+// ResourceIDSegment is a helper which returns a Segment for a ResourceID
+// This is used by the Composite Resource ID
+func ResourceIDSegment(name, exampleValue string) Segment {
+	return Segment{
+		Name:         name,
+		Type:         ResourceIDSegmentType,
 		ExampleValue: exampleValue,
 	}
 }


### PR DESCRIPTION


<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Changes to the `azurerm` provider require that the `CompositeResourceID` implements the `resourceids.ResourceId` interface, updated both the interface and the `CompositeResourceID` implementation


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* added new function `AFunction` [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature
- [x] Enhancement
- [ ] Breaking Change




<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
