### PR TITLE
keyvault: support for non-default ports

### DIFF
--- a/resourcemanager/keyvault/nested_item.go
+++ b/resourcemanager/keyvault/nested_item.go
@@ -34,9 +34,7 @@ func NewNestedItemID(keyVaultBaseURL string, nestedItemType NestedItemType, name
 		return nil, fmt.Errorf("parsing `%s`: %w", keyVaultBaseURL, err)
 	}
 
-	if hostParts := strings.Split(keyVaultUrl.Host, ":"); len(hostParts) > 1 {
-		keyVaultUrl.Host = hostParts[0]
-	}
+	keyVaultUrl.Host = stripDefaultPort(keyVaultUrl.Scheme, keyVaultUrl.Host)
 
 	return &NestedItemID{
 		KeyVaultBaseURL: strings.TrimSuffix(keyVaultUrl.String(), "/"),
@@ -128,7 +126,7 @@ func parseNestedItemID(input string) (*NestedItemID, error) {
 	}
 
 	return &NestedItemID{
-		KeyVaultBaseURL: fmt.Sprintf("%s://%s", inputUrl.Scheme, inputUrl.Host),
+		KeyVaultBaseURL: fmt.Sprintf("%s://%s", inputUrl.Scheme, stripDefaultPort(inputUrl.Scheme, inputUrl.Host)),
 		NestedItemType:  NestedItemType(pathSegments[0]),
 		Name:            pathSegments[1],
 		Version:         version,
@@ -173,4 +171,20 @@ func ValidateNestedItemName(v interface{}, k string) (warnings []string, errors 
 // This can be used to determine whether to set `managed_hsm_key_id` into state while this argument is in a deprecated state.
 func (id NestedItemID) IsManagedHSM() bool {
 	return strings.Contains(id.KeyVaultBaseURL, ".managedhsm.")
+}
+
+// stripDefaultPort removes the port when it's the default for that scheme
+// for example when :443 is included in the response.
+//
+// This allows handling cases where a non-default port may be being used.
+func stripDefaultPort(scheme, hostname string) string {
+	idx := strings.LastIndex(hostname, ":")
+	if idx < 0 {
+		return hostname
+	}
+	port := hostname[idx+1:]
+	if strings.EqualFold(scheme, "https") && port == "443" {
+		return hostname[:idx]
+	}
+	return hostname
 }

--- a/resourcemanager/keyvault/nested_item_test.go
+++ b/resourcemanager/keyvault/nested_item_test.go
@@ -1,8 +1,6 @@
 package keyvault
 
-import (
-	"testing"
-)
+import "testing"
 
 func TestNewNestedItemID(t *testing.T) {
 	cases := []struct {
@@ -39,6 +37,12 @@ func TestNewNestedItemID(t *testing.T) {
 			Scenario:        "managed hsm valid, with port",
 			KeyVaultBaseURL: "https://test.managedhsm.azure.net:443",
 			Expected:        "https://test.managedhsm.azure.net/keys/test/testVersionString",
+			ExpectError:     false,
+		},
+		{
+			Scenario:        "valid, a non default port gets preserved",
+			KeyVaultBaseURL: "https://test.example:5661",
+			Expected:        "https://test.example:5661/keys/test/testVersionString",
 			ExpectError:     false,
 		},
 	}
@@ -144,6 +148,18 @@ func TestParseNestedItemID(t *testing.T) {
 				NestedItemType:  NestedItemTypeKey,
 				KeyVaultBaseURL: "https://my-keyvault.managedhsm.azure.net",
 				Version:         "1492",
+			},
+		},
+		{
+			// When the API returns a non-default port (e.g. not HTTPS:443)
+			// we should ensure the port is included when round-tripped.
+			Input:       "https://my-keyvault.example:5661/keys/castle/fdf067c93bbb4b22bff4d8b7a9a56217",
+			ExpectError: false,
+			Expected: NestedItemID{
+				Name:            "castle",
+				NestedItemType:  NestedItemTypeKey,
+				KeyVaultBaseURL: "https://my-keyvault.example:5661",
+				Version:         "fdf067c93bbb4b22bff4d8b7a9a56217",
 			},
 		},
 	}


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This commit fixes an issue where a non-default is being used but the port gets stripped.

This handles this in a backwards-compatible way by stripping the port from the response to normalise it when the port being used matches the default for the scheme being used.

For example, this means that `https://example:443` continues being flattened down to `https://example` - but `https://example:444` will be retained as-is.

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

* `keyvault`: support for non-default ports

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [x] Enhancement
