### PR TITLE
resourcemanager/tags, framework/commonschema: support provider-level ignore_tags

### DIFF
--- a/framework/commonschema/tags.go
+++ b/framework/commonschema/tags.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/framework/convert"
 	"github.com/hashicorp/go-azure-helpers/framework/typehelpers"
+	rmtags "github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	datasourceschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -48,11 +49,16 @@ func ExpandTags(ctx context.Context, input typehelpers.MapValueOf[types.String],
 
 	convert.Expand(ctx, input, &result, diags)
 
-	return &result
+	// exclude any provider-level ignored tag keys from the desired set
+	return rmtags.Ignore().ApplyPtrMap(&result)
 }
 
 func FlattenTags(ctx context.Context, tags *map[string]string, diags *diag.Diagnostics) typehelpers.MapValueOf[types.String] {
+	// scrub any provider-level ignored tag keys before they reach state
+	tags = rmtags.Ignore().ApplyPtrMap(tags)
+
 	result := typehelpers.NewMapValueOfNull[types.String](ctx)
+
 	if tags == nil {
 		return result
 	}

--- a/framework/commonschema/tags_test.go
+++ b/framework/commonschema/tags_test.go
@@ -1,0 +1,66 @@
+// Copyright IBM Corp. 2018, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package commonschema
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/framework/typehelpers"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestExpandTagsHonoursIgnoreConfig(t *testing.T) {
+	t.Cleanup(func() { tags.SetIgnore(nil) })
+	tags.SetIgnore(&tags.IgnoreConfig{Keys: []string{"createdBy"}})
+
+	ctx := context.Background()
+	input := typehelpers.NewMapValueOfMust[types.String](ctx, map[string]attr.Value{
+		"environment": types.StringValue("prod"),
+		"createdBy":   types.StringValue("policy"),
+	})
+
+	var diags diag.Diagnostics
+	result := ExpandTags(ctx, input, &diags)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics from ExpandTags: %v", diags)
+	}
+	if result == nil {
+		t.Fatalf("expected non-nil result")
+	}
+	if len(*result) != 1 {
+		t.Fatalf("expected ignored key to be excluded, got %v", *result)
+	}
+	if (*result)["environment"] != "prod" {
+		t.Fatalf("expected environment=prod, got %v", *result)
+	}
+}
+
+func TestFlattenTagsHonoursIgnoreConfig(t *testing.T) {
+	t.Cleanup(func() { tags.SetIgnore(nil) })
+	tags.SetIgnore(&tags.IgnoreConfig{KeyPrefixes: []string{"azure-policy-"}})
+
+	ctx := context.Background()
+	input := map[string]string{
+		"environment":     "prod",
+		"azure-policy-id": "abc",
+	}
+
+	var diags diag.Diagnostics
+	result := FlattenTags(ctx, &input, &diags)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics from FlattenTags: %v", diags)
+	}
+
+	elems := result.Elements()
+	if len(elems) != 1 {
+		t.Fatalf("expected ignored prefix key to be scrubbed, got %v", elems)
+	}
+	if _, ok := elems["environment"]; !ok {
+		t.Fatalf("expected environment to be retained, got %v", elems)
+	}
+}

--- a/resourcemanager/tags/expand.go
+++ b/resourcemanager/tags/expand.go
@@ -13,5 +13,6 @@ func Expand(input map[string]interface{}) *map[string]string {
 		output[tagKey] = tagValue
 	}
 
-	return &output
+	// exclude any provider-level ignored tag keys from the desired set
+	return Ignore().ApplyPtrMap(&output)
 }

--- a/resourcemanager/tags/flatten.go
+++ b/resourcemanager/tags/flatten.go
@@ -12,6 +12,9 @@ import (
 // Flatten transforms the Tags specified via `input` into a map[string]interface{}
 // for compatibility with the Schema.
 func Flatten(input *map[string]string) map[string]interface{} {
+	// scrub any provider-level ignored tag keys before they reach state
+	input = Ignore().ApplyPtrMap(input)
+
 	output := make(map[string]interface{})
 	if input == nil {
 		return output

--- a/resourcemanager/tags/ignore.go
+++ b/resourcemanager/tags/ignore.go
@@ -1,0 +1,87 @@
+// Copyright IBM Corp. 2018, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package tags
+
+import "strings"
+
+// IgnoreConfig describes the set of tag keys that the provider should ignore on
+// every resource and data source. A key is ignored when it exactly matches an
+// entry in Keys (case-sensitive) or when it begins with an entry in KeyPrefixes.
+type IgnoreConfig struct {
+	Keys        []string
+	KeyPrefixes []string
+}
+
+// ignore is the process-wide IgnoreConfig set once when the provider is
+// configured. A nil value means no tags are ignored, preserving the default
+// behavior for anyone who does not configure the `ignore_tags` block.
+var ignore *IgnoreConfig
+
+// SetIgnore stores the provider-level IgnoreConfig so that the tag helpers in
+// this package (and the framework helpers that read Ignore()) apply it.
+func SetIgnore(config *IgnoreConfig) {
+	ignore = config
+}
+
+// Ignore returns the process-wide IgnoreConfig, or nil if none is configured.
+func Ignore() *IgnoreConfig {
+	return ignore
+}
+
+// ignored reports whether the tag key should be ignored under this config.
+func (c *IgnoreConfig) ignored(key string) bool {
+	if c == nil {
+		return false
+	}
+
+	for _, k := range c.Keys {
+		if key == k {
+			return true
+		}
+	}
+
+	for _, prefix := range c.KeyPrefixes {
+		if strings.HasPrefix(key, prefix) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// ApplyPtrMap returns a copy of input with every ignored key removed. A nil
+// receiver or a nil input is returned unchanged.
+func (c *IgnoreConfig) ApplyPtrMap(input *map[string]string) *map[string]string {
+	if c == nil || input == nil {
+		return input
+	}
+
+	output := make(map[string]string, len(*input))
+	for k, v := range *input {
+		if c.ignored(k) {
+			continue
+		}
+		output[k] = v
+	}
+
+	return &output
+}
+
+// ApplyMap returns a copy of input with every ignored key removed. A nil
+// receiver is returned unchanged.
+func (c *IgnoreConfig) ApplyMap(input map[string]*string) map[string]*string {
+	if c == nil {
+		return input
+	}
+
+	output := make(map[string]*string, len(input))
+	for k, v := range input {
+		if c.ignored(k) {
+			continue
+		}
+		output[k] = v
+	}
+
+	return output
+}

--- a/resourcemanager/tags/ignore_test.go
+++ b/resourcemanager/tags/ignore_test.go
@@ -1,0 +1,163 @@
+// Copyright IBM Corp. 2018, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package tags
+
+import (
+	"testing"
+)
+
+func strPtr(s string) *string {
+	return &s
+}
+
+func TestIgnoreConfigApplyPtrMap(t *testing.T) {
+	testCases := []struct {
+		name     string
+		config   *IgnoreConfig
+		input    map[string]string
+		expected map[string]string
+	}{
+		{
+			name:     "nil config is a no-op",
+			config:   nil,
+			input:    map[string]string{"environment": "prod", "createdBy": "policy"},
+			expected: map[string]string{"environment": "prod", "createdBy": "policy"},
+		},
+		{
+			name:     "empty config is a no-op",
+			config:   &IgnoreConfig{},
+			input:    map[string]string{"environment": "prod", "createdBy": "policy"},
+			expected: map[string]string{"environment": "prod", "createdBy": "policy"},
+		},
+		{
+			name:     "exact key is removed",
+			config:   &IgnoreConfig{Keys: []string{"createdBy"}},
+			input:    map[string]string{"environment": "prod", "createdBy": "policy"},
+			expected: map[string]string{"environment": "prod"},
+		},
+		{
+			name:     "exact key match is case-sensitive",
+			config:   &IgnoreConfig{Keys: []string{"createdby"}},
+			input:    map[string]string{"environment": "prod", "createdBy": "policy"},
+			expected: map[string]string{"environment": "prod", "createdBy": "policy"},
+		},
+		{
+			name:     "key prefix is removed",
+			config:   &IgnoreConfig{KeyPrefixes: []string{"azure-policy-"}},
+			input:    map[string]string{"environment": "prod", "azure-policy-id": "abc", "azure-policy-name": "def"},
+			expected: map[string]string{"environment": "prod"},
+		},
+		{
+			name:     "key prefix match is case-sensitive",
+			config:   &IgnoreConfig{KeyPrefixes: []string{"Azure-Policy-"}},
+			input:    map[string]string{"azure-policy-id": "abc"},
+			expected: map[string]string{"azure-policy-id": "abc"},
+		},
+		{
+			name:     "union of keys and key_prefixes",
+			config:   &IgnoreConfig{Keys: []string{"createdBy"}, KeyPrefixes: []string{"internal:"}},
+			input:    map[string]string{"environment": "prod", "createdBy": "policy", "internal:owner": "x", "internal:cost": "y"},
+			expected: map[string]string{"environment": "prod"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.config.ApplyPtrMap(&tc.input)
+			if result == nil {
+				t.Fatalf("expected non-nil result")
+			}
+			if len(*result) != len(tc.expected) {
+				t.Fatalf("expected %d tags, got %d: %v", len(tc.expected), len(*result), *result)
+			}
+			for k, v := range tc.expected {
+				if (*result)[k] != v {
+					t.Fatalf("expected %q=%q, got %q", k, v, (*result)[k])
+				}
+			}
+		})
+	}
+}
+
+func TestIgnoreConfigApplyPtrMapNilInput(t *testing.T) {
+	config := &IgnoreConfig{Keys: []string{"createdBy"}}
+	if result := config.ApplyPtrMap(nil); result != nil {
+		t.Fatalf("expected nil result for nil input, got %v", result)
+	}
+}
+
+func TestIgnoreConfigApplyMap(t *testing.T) {
+	config := &IgnoreConfig{Keys: []string{"createdBy"}, KeyPrefixes: []string{"internal:"}}
+	input := map[string]*string{
+		"environment":    strPtr("prod"),
+		"createdBy":      strPtr("policy"),
+		"internal:owner": strPtr("x"),
+	}
+
+	result := config.ApplyMap(input)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 tag, got %d: %v", len(result), result)
+	}
+	if result["environment"] == nil || *result["environment"] != "prod" {
+		t.Fatalf("expected environment=prod to be retained, got %v", result["environment"])
+	}
+}
+
+func TestIgnoreConfigApplyMapNilReceiver(t *testing.T) {
+	var config *IgnoreConfig
+	input := map[string]*string{"createdBy": strPtr("policy")}
+	result := config.ApplyMap(input)
+	if len(result) != 1 {
+		t.Fatalf("expected nil receiver to be a no-op, got %v", result)
+	}
+}
+
+func TestSetIgnoreAndIgnoreRoundTrip(t *testing.T) {
+	t.Cleanup(func() { SetIgnore(nil) })
+
+	if Ignore() != nil {
+		t.Fatalf("expected nil ignore config by default")
+	}
+
+	cfg := &IgnoreConfig{Keys: []string{"createdBy"}}
+	SetIgnore(cfg)
+	if Ignore() != cfg {
+		t.Fatalf("expected Ignore() to return the configured value")
+	}
+}
+
+func TestExpandHonoursActiveIgnoreConfig(t *testing.T) {
+	t.Cleanup(func() { SetIgnore(nil) })
+	SetIgnore(&IgnoreConfig{Keys: []string{"createdBy"}})
+
+	result := Expand(map[string]interface{}{
+		"environment": "prod",
+		"createdBy":   "policy",
+	})
+
+	if len(*result) != 1 {
+		t.Fatalf("expected ignored key to be excluded on expand, got %v", *result)
+	}
+	if (*result)["environment"] != "prod" {
+		t.Fatalf("expected environment=prod, got %v", *result)
+	}
+}
+
+func TestFlattenHonoursActiveIgnoreConfig(t *testing.T) {
+	t.Cleanup(func() { SetIgnore(nil) })
+	SetIgnore(&IgnoreConfig{KeyPrefixes: []string{"azure-policy-"}})
+
+	input := map[string]string{
+		"environment":     "prod",
+		"azure-policy-id": "abc",
+	}
+	result := Flatten(&input)
+
+	if len(result) != 1 {
+		t.Fatalf("expected ignored prefix key to be scrubbed on flatten, got %v", result)
+	}
+	if result["environment"] != "prod" {
+		t.Fatalf("expected environment=prod, got %v", result)
+	}
+}


### PR DESCRIPTION
## Community Note

* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

Adds support for a provider-level "ignore tags" capability to the shared tag helpers, mirroring the AWS provider's [ignoring changes in all resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/resource-tagging#ignoring-changes-in-all-resources) feature.

This introduces a new `IgnoreConfig` in `resourcemanager/tags`:

* `IgnoreConfig{ Keys, KeyPrefixes }` — case-sensitive exact-key and `key_prefix` ("starts with") matching.
* A package-level `SetIgnore(*IgnoreConfig)` / `Ignore() *IgnoreConfig` hook so a provider can configure the ignore set once at provider-configure time.
* `ApplyMap` / `ApplyPtrMap` helpers that scrub ignored keys from a tag map (nil-safe on a nil receiver and nil map).

The existing tag `Expand`/`Flatten` helpers in both `resourcemanager/tags` and `framework/commonschema` now consult the configured `IgnoreConfig`:

* **Flatten (read):** ignored keys are scrubbed before being written to state, so an externally-applied tag never lands in state and never shows as drift.
* **Expand (create/update):** ignored keys are excluded from the desired set.

Applied symmetrically, an ignored tag is never added and is never reported as drift. When no config is set (the default), every code path is a no-op, so existing behaviour is unchanged.

This is the upstream half required by hashicorp/terraform-provider-azurerm#32664, which adds a provider-level `ignore_tags` block consuming this hook. That PR currently `replace`s this module with this branch temporarily; once this is merged and released, the `replace` will be dropped and the version bumped.

Unit tests are included for `IgnoreConfig` (exact keys, key prefixes, union, case-sensitivity, nil/empty no-op, nil map) and for `Expand`/`Flatten` honouring an active config, on both the `resourcemanager/tags` and `framework/commonschema` helpers.

## Change Log

* `resourcemanager/tags`: support for provider-level ignoring of tag keys and key prefixes via `IgnoreConfig` and the package-level `SetIgnore`/`Ignore` hook [GH-00000]
* `framework/commonschema`: tag `Expand`/`Flatten` now honour the configured `IgnoreConfig` [GH-00000]

This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature
- [ ] Enhancement
- [ ] Breaking Change

## Related Issue(s)

Backs hashicorp/terraform-provider-azurerm#32664 (and the feature request hashicorp/terraform-provider-azurerm#28711).

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

No changes to security controls. The change only filters which tag keys are written to / read from Terraform state based on user-supplied configuration; no access controls, encryption, or logging are affected.
