### PR TITLE
`pointer` - add helper to convert slice of strings to slice of enum type and vice-versa

### DIFF
--- a/lang/pointer/generic.go
+++ b/lang/pointer/generic.go
@@ -27,6 +27,18 @@ func FromEnum[T ~string](input *T) (output string) {
 	return string(*input)
 }
 
+// FromEnumSlice is a helper function to convert a pointer to a slice of an Enum type to a slice of strings
+func FromEnumSlice[T ~string](input *[]T) []string {
+	if input == nil {
+		return nil
+	}
+	result := make([]string, 0, len(*input))
+	for _, v := range *input {
+		result = append(result, string(v))
+	}
+	return result
+}
+
 // To is a generic function that returns a pointer to the value provided.
 func To[T any](input T) *T {
 	return &input
@@ -39,5 +51,14 @@ func To[T any](input T) *T {
 // APIModel.SomeValue = pointer.ToEnum[someservice.SomeEnumType](model.SomeVariable)
 func ToEnum[T ~string](input string) *T {
 	result := T(input)
+	return &result
+}
+
+// ToEnumSlice is a helper function to convert a slice of strings to a slice of an Enum type
+func ToEnumSlice[T ~string](input []string) *[]T {
+	result := make([]T, 0, len(input))
+	for _, v := range input {
+		result = append(result, T(v))
+	}
 	return &result
 }


### PR DESCRIPTION

<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This will remove the need for many bespoke flatten/expand funcs in `azurerm` since this is a very common conversion we have to handle when moving from API -> Terraform values and vice-versa


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* added new function `AFunction` [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
